### PR TITLE
이름 변경 시간 제한 설정

### DIFF
--- a/src/constant/exception.ts
+++ b/src/constant/exception.ts
@@ -4,7 +4,7 @@ import { HttpStatus } from '@nestjs/common';
 export enum ExceptionCode {
   // 400 (Bad Request)
   InvalidParameter = 'INVALID_PARAMETER',
-  RowLimitExceeded = 'ROW_LIMIT_EXCEEDED',
+  LimitExceeded = 'LIMIT_EXCEEDED',
   InvalidDate = 'INVALID_DATE',
 
   // 401 (Unauthorized)
@@ -34,8 +34,7 @@ export const ExceptionMessage: {
 } = {
   // 400 (Bad Request)
   [ExceptionCode.InvalidParameter]: 'Invalid Parameter',
-  [ExceptionCode.RowLimitExceeded]:
-    'Exceeded the maximum download row count 10,000',
+  [ExceptionCode.LimitExceeded]: 'Limit Exceeded',
 
   // 401 (Unauthorized)
   // token is null/undefined
@@ -65,7 +64,7 @@ export const CodeToStatus: {
   [key in ExceptionCode]: HttpStatus;
 } = {
   [ExceptionCode.InvalidParameter]: HttpStatus.BAD_REQUEST,
-  [ExceptionCode.RowLimitExceeded]: HttpStatus.BAD_REQUEST,
+  [ExceptionCode.LimitExceeded]: HttpStatus.BAD_REQUEST,
   [ExceptionCode.MissingAuthToken]: HttpStatus.UNAUTHORIZED,
   [ExceptionCode.InvalidAccessToken]: HttpStatus.UNAUTHORIZED,
   [ExceptionCode.TokenExpired]: HttpStatus.UNAUTHORIZED,

--- a/src/module/cache/dto/cache.dto.ts
+++ b/src/module/cache/dto/cache.dto.ts
@@ -1,0 +1,9 @@
+import { RedisKey } from '../enum/cache.enum';
+
+export class EditUserNameKey {
+  static editUserNamePrefix: string = RedisKey.EditUserName;
+
+  static get(userId: number): string {
+    return [this.editUserNamePrefix, userId].join(':');
+  }
+}

--- a/src/module/cache/enum/cache.enum.ts
+++ b/src/module/cache/enum/cache.enum.ts
@@ -1,0 +1,3 @@
+export enum RedisKey {
+  EditUserName = 'edit_username',
+}

--- a/src/module/config/Configuration.ts
+++ b/src/module/config/Configuration.ts
@@ -37,4 +37,7 @@ export interface Configuration {
   // In-momory DB
   REDIS_HOST: string;
   REDIS_PORT: number;
+  REDIS_TTL: {
+    EDIT_NAME: number;
+  };
 }

--- a/src/module/config/Development.ts
+++ b/src/module/config/Development.ts
@@ -33,6 +33,9 @@ const config: Configuration = {
   // In-momory DB
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,
+  REDIS_TTL: {
+    EDIT_NAME: 10 * 60 * 1000, // 10분
+  },
 };
 
 export default config;

--- a/src/module/config/Local.ts
+++ b/src/module/config/Local.ts
@@ -33,6 +33,9 @@ const config: Configuration = {
   // In-momory DB
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,
+  REDIS_TTL: {
+    EDIT_NAME: 3 * 60 * 1000, // 3분
+  },
 };
 
 export default config;

--- a/src/module/config/Production.ts
+++ b/src/module/config/Production.ts
@@ -33,6 +33,9 @@ const config: Configuration = {
   // In-momory DB
   REDIS_HOST: 'localhost',
   REDIS_PORT: 6379,
+  REDIS_TTL: {
+    EDIT_NAME: 24 * 60 * 60 * 1000, // 24시간
+  },
 };
 
 export default config;

--- a/src/module/user/user.controller.ts
+++ b/src/module/user/user.controller.ts
@@ -23,6 +23,8 @@ import { ResponseException } from 'src/decorator/response-exception.decorator';
 import { ExceptionCode } from 'src/constant/exception';
 import { ResponsesListDto } from 'src/dto/responses-list.dto';
 import { UserEntity } from '../repository/entity/user.entity';
+import { HttpError } from 'src/types/http-exceptions';
+import { ConfigService } from '../config/config.service';
 
 @Controller({
   path: 'user',
@@ -56,18 +58,29 @@ export class UserController {
   @ApiTags('User')
   @ApiOperation({
     summary: '유저 이름 변경',
-    description: '이미 존재하는 이름일 경우 409 ALREADY_EXISTS',
+    description: `
+    이미 존재하는 이름일 경우 409 ALREADY_EXISTS\n
+    ${ConfigService.getConfig().REDIS_TTL.EDIT_NAME / 1000} 초가 지나기 전에 이름을 바꾸는 경우\n
+    -> 409 LIMIT_EXCEEDED\n
+    [이름 변경 제한] dev 서버 10분, prod 24시간
+    `,
   })
   @ApiBearerAuth(AuthorizationToken.BearerUserToken)
   @UseGuards(AuthGuard)
   @HttpCode(HttpStatus.OK)
   @ResponseData(UserInfoResponse)
-  @ResponseException(HttpStatus.CONFLICT, [ExceptionCode.DuplicateValues])
+  @ResponseException(HttpStatus.CONFLICT, [
+    ExceptionCode.DuplicateValues,
+    ExceptionCode.LimitExceeded,
+  ])
   @Patch('name')
   async updateUserName(
     @Body() dto: UpdateUserNameRequest,
   ): Promise<ResponsesDataDto<UserInfoResponse>> {
     const { user } = this.req;
+    if (!(await this.userService.canEditName(user.id))) {
+      throw new HttpError(HttpStatus.CONFLICT, ExceptionCode.LimitExceeded);
+    }
     const result = await this.userService.updateUserName(user.id, dto.name);
 
     return new ResponsesDataDto(result);


### PR DESCRIPTION
### 기존 이름 변경 PATCH API 에 시간 제한 추가

> #### 이름 변경 요청
> #### => In-memory DB(Redis) 에서 userId 확인
> #### => 있으면 409, LIMIT_EXCEEDED 에러 
>  #### => 없으면 이름 변경 처리,  만료 시간 설정해서 Redis 에 세팅

<제한 만료시간>
- Production 환경: 24시간
- Development : 10분
- Local: 3분 
테스트 고려해서 Local 이랑 dev 는 일부러 짧게 잡았어요! 
프로덕션 환경에서 24시간은 우선 제가 임의로 설정해봤습니다~ 
