### PR TITLE
특정 1:1 문의 조회 API 추가 및 예외처리 수정

### DIFF
--- a/src/module/repository/service/support.repository.service.ts
+++ b/src/module/repository/service/support.repository.service.ts
@@ -48,8 +48,14 @@ export class SupportRepositoryService {
     await this.qnaRepository.delete(questionId);
   }
 
-  async getQuestionById(questionId: number): Promise<QnaEntity> {
-    const question = this.qnaRepository.findOneBy({ id: questionId });
+  async getQuestionById(
+    userId: number,
+    questionId: number,
+  ): Promise<QnaEntity> {
+    const question = await this.qnaRepository.findOneBy({
+      id: questionId,
+      userId,
+    });
 
     if (!question) {
       throw new ServiceError(ExceptionCode.NotFound);

--- a/src/module/support/support.controller.ts
+++ b/src/module/support/support.controller.ts
@@ -34,6 +34,7 @@ import { ResponsesDataDto } from 'src/dto/responses-data.dto';
 import { AuthorizationToken } from 'src/constant/authorization-token';
 import { ResponseException } from 'src/decorator/response-exception.decorator';
 import { ExceptionCode } from 'src/constant/exception';
+import { ResponseData } from 'src/decorator/response-data.decorator';
 
 @Controller({
   path: 'support',
@@ -120,5 +121,23 @@ export class SupportController {
     const result = await this.supportService.getQnasByUserId(user.id);
 
     return new ResponsesListDto(result);
+  }
+
+  @ApiTags('Support')
+  @ApiOperation({
+    summary: '특정 1:1 문의 조회',
+  })
+  @ApiBearerAuth(AuthorizationToken.BearerUserToken)
+  @UseGuards(AuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ResponseData(QnaResponse)
+  @Get('qna:id')
+  async getQnaById(
+    @Param('id') id: number,
+  ): Promise<ResponsesDataDto<QnaResponse>> {
+    const { user } = this.req;
+    const result = await this.supportService.getQnaById(user.id, id);
+
+    return new ResponsesDataDto(result);
   }
 }

--- a/src/module/support/support.service.ts
+++ b/src/module/support/support.service.ts
@@ -40,11 +40,7 @@ export class SupportService {
     questionId: number,
     params: PostQuestionRequest,
   ): Promise<void> {
-    const question =
-      await this.supportRepositoryService.getQuestionById(questionId);
-    if (userId !== question.userId) {
-      throw new ServiceError(ExceptionCode.NotFound);
-    }
+    await this.supportRepositoryService.getQuestionById(userId, questionId);
 
     const postQuestion = {
       ...params,
@@ -57,11 +53,7 @@ export class SupportService {
   }
 
   async deleteQuestion(userId: number, questionId: number): Promise<void> {
-    const question =
-      await this.supportRepositoryService.getQuestionById(questionId);
-    if (userId !== question.userId) {
-      throw new ServiceError(ExceptionCode.NotFound);
-    }
+    await this.supportRepositoryService.getQuestionById(userId, questionId);
 
     await this.supportRepositoryService.deleteQuestion(questionId);
   }
@@ -71,5 +63,11 @@ export class SupportService {
     const result = qnas.map((e) => QnaResponse.from(e));
 
     return result;
+  }
+
+  async getQnaById(userId: number, id: number): Promise<QnaResponse> {
+    const qna = await this.supportRepositoryService.getQuestionById(userId, id);
+
+    return QnaResponse.from(qna);
   }
 }


### PR DESCRIPTION
### 변경사항 

- 1:1 문의  id로 하나씩 조회하는 API 
    _/v1/support/qna/:id_ **GET**

- 추가하면서 `SupportService`의 `updateQuestion()`, `deleteQuestion()`  `getQnaById() `메서드에서 
   **로그인한 유저의 QnA인지 확인하는 로직**이 동일하게 들어가서
   SupportRepositoryService 안으로 넣었습니다. 
  
관리자 페이지는 아닐 수 있는데
더즐에서는 Qna 를 조회할 땐 무조건 **해당 유저의 Qna 를 가져오는 경우만** 있어서
Repository 레벨부터 userId 랑 같이 조회해서 예외처리 하는 편이 깔끔해보여서요! 
