### PR TITLE
서버시작시 DB에 20개의 구역 데이터 세팅

### DIFF
--- a/src/constant/zones.ts
+++ b/src/constant/zones.ts
@@ -1,0 +1,110 @@
+import { OmitType } from '@nestjs/swagger';
+import { ZoneEntity } from 'src/module/repository/entity/zone.entity';
+
+export class Zone extends OmitType(ZoneEntity, [
+  'createdAt',
+  'updatedAt',
+] as const) {}
+
+export const ZONES: Zone[] = [
+  {
+    id: 0,
+    nameKr: '정문・대학본부',
+    nameUs: 'Entrance & Administration Building',
+  },
+  {
+    id: 1,
+    nameKr: '스머프동산',
+    nameUs: 'Smurf Hill',
+  },
+  {
+    id: 2,
+    nameKr: '인문사회관',
+    nameUs: 'College of Humanities & Social Sciences',
+  },
+  {
+    id: 3,
+    nameKr: '대강의동',
+    nameUs: 'Lecture Hall',
+  },
+  {
+    id: 4,
+    nameKr: '차미리사기념관',
+    nameUs: 'ChaMirisa Memorial Building',
+  },
+  {
+    id: 5,
+    nameKr: '학생회관',
+    nameUs: 'Student Union',
+  },
+  {
+    id: 6,
+    nameKr: '도서관・대학원',
+    nameUs: '"Main Library & Graduate School',
+  },
+  {
+    id: 7,
+    nameKr: '민주동산',
+    nameUs: '"Liberty Hill',
+  },
+  {
+    id: 8,
+    nameKr: '영근터',
+    nameUs: 'Younggeunteo',
+  },
+  {
+    id: 9,
+    nameKr: '덕우당',
+    nameUs: 'Duk Woo Dang',
+  },
+  {
+    id: 10,
+    nameKr: '테니스장',
+    nameUs: 'tennis court',
+  },
+  {
+    id: 11,
+    nameKr: '유아교육관',
+    nameUs: 'Affiliated Kindergarten',
+  },
+  {
+    id: 12,
+    nameKr: '대운동장',
+    nameUs: 'Stadium',
+  },
+  {
+    id: 13,
+    nameKr: '예술관',
+    nameUs: 'College of Art & Design',
+  },
+  {
+    id: 14,
+    nameKr: '자연관・비엔나숲',
+    nameUs: 'College of Natural Sciences & Vienna Forest',
+  },
+  {
+    id: 15,
+    nameKr: '약학관・아트홀',
+    nameUs: 'College of Pharmacy & Art Hall',
+  },
+  {
+    id: 16,
+    nameKr: '덕성하나누리관 & 라온센터',
+    nameUs: 'Hana Nuri Hall & Raon Center(Fitness Center)',
+  },
+  {
+    id: 17,
+    nameKr: '국제관',
+    nameUs: '"International Hall',
+  },
+  {
+    id: 18,
+    nameKr: '기숙사(가온 I관, 가온 II 관)',
+    nameUs: 'Dormitory(Gain I, Gain II)',
+  },
+  {
+    id: 19,
+    nameKr: '국제기숙사',
+    nameUs: 'International Dormitory',
+  },
+] as const;

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import {
 } from '@nestjs/platform-express';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 import { setupSwagger } from './setup-swagger';
+import { ZoneService } from './module/zone/zone.service';
 
 async function bootstrap() {
   initializeTransactionalContext();
@@ -123,6 +124,9 @@ async function bootstrap() {
   }
 
   await app.listen(port);
+
+  // zones.ts 에 정의한 zone 목록으로 DB 초기화
+  await app.get<ZoneService>(ZoneService).setZones();
 
   console.info(
     `Server ${ConfigService.getConfig().ENV} running on port ${port}`,

--- a/src/module/main.module.ts
+++ b/src/module/main.module.ts
@@ -19,6 +19,7 @@ import { NotFoundExceptionFilter } from 'src/filter/not-found-exception.filter';
 import { HttpExceptionFilter } from 'src/filter/http-exception.filter';
 import { MailModule } from './email/email.module';
 import { QuestModule } from './quest/quest.module';
+import { ZoneModule } from './zone/zone.module';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { QuestModule } from './quest/quest.module';
     UserModule,
     MailModule,
     QuestModule,
+    ZoneModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/src/module/repository/entity/zone.entity.ts
+++ b/src/module/repository/entity/zone.entity.ts
@@ -1,0 +1,25 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('zone')
+export class ZoneEntity {
+  @PrimaryColumn({ type: 'int' })
+  id: number;
+
+  @Column('varchar')
+  nameKr: string;
+
+  @Column('varchar')
+  nameUs: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/src/module/repository/repository.module.ts
+++ b/src/module/repository/repository.module.ts
@@ -8,6 +8,8 @@ import { QnaEntity } from './entity/qna.entity';
 import { QuestRepositoryService } from './service/quest.repository.service';
 import { QuestEntity } from './entity/quest.entity';
 import { LogQuestEntity } from './entity/log-quest.entity';
+import { ZoneEntity } from './entity/zone.entity';
+import { ZoneRepositoryService } from './service/zone.repository.service';
 
 @Module({
   imports: [
@@ -17,17 +19,20 @@ import { LogQuestEntity } from './entity/log-quest.entity';
       QnaEntity,
       QuestEntity,
       LogQuestEntity,
+      ZoneEntity,
     ]),
   ],
   providers: [
     UserRepositoryService,
     SupportRepositoryService,
     QuestRepositoryService,
+    ZoneRepositoryService,
   ],
   exports: [
     UserRepositoryService,
     SupportRepositoryService,
     QuestRepositoryService,
+    ZoneRepositoryService,
   ],
 })
 export class RepositoryModule {}

--- a/src/module/repository/service/zone.repository.service.ts
+++ b/src/module/repository/service/zone.repository.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { ZoneEntity } from '../entity/zone.entity';
+import { ZONES } from 'src/constant/zones';
+
+@Injectable()
+export class ZoneRepositoryService {
+  constructor(
+    @InjectRepository(ZoneEntity)
+    private zoneRepository: Repository<ZoneEntity>,
+  ) {}
+
+  // 정의된 zone 목록을 DB 에 새롭게 세팅
+  async setZones() {
+    await this.zoneRepository.delete({});
+    await this.zoneRepository.insert(ZONES);
+  }
+}

--- a/src/module/zone/zone.module.ts
+++ b/src/module/zone/zone.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RepositoryModule } from 'src/module/repository/repository.module';
+import { ZoneService } from './zone.service';
+
+@Module({
+  imports: [RepositoryModule],
+  providers: [ZoneService],
+  exports: [ZoneService],
+})
+export class ZoneModule {}

--- a/src/module/zone/zone.service.ts
+++ b/src/module/zone/zone.service.ts
@@ -1,0 +1,13 @@
+import { Inject } from '@nestjs/common';
+import { ZoneRepositoryService } from '../repository/service/zone.repository.service';
+
+export class ZoneService {
+  constructor(
+    @Inject(ZoneRepositoryService)
+    private readonly zoneRepositoryService: ZoneRepositoryService,
+  ) {}
+
+  async setZones(): Promise<void> {
+    await this.zoneRepositoryService.setZones();
+  }
+}


### PR DESCRIPTION
### 서버시작시 DB에 20개의 구역 데이터 세팅

- DB schema
   zone table
<img width="402" alt="image" src="https://github.com/Duksung-Kkureogi/duzzle-be/assets/158791917/02c61ea1-8a30-433c-8f2e-22a8dd1f2ae7">


- 고정된 zone 배열이 필요, zones.ts 에 정의
- DB 에 직접 추가하거나 변경할 경우 휴먼에러 발생 가능성 높음
- duzzle 에서 필요한 구역 목록을 파일에서 정의하고 서버 재시작시 DB 에 자동 세팅되도록 main.ts 변경

- 스토리 등에서 필요할 것 같아서 작업하였습니다. 
- 스토리 테이블 등에서 zone 테이블과도 관계 잡아두면 이후에 관리자 페이지에서 통계 데이터 확인하기에도 수월할 것 같아서요! 

- zone table 에 세팅된 데이터
<img width="1050" alt="image" src="https://github.com/Duksung-Kkureogi/duzzle-be/assets/158791917/b79c95b8-6a70-4325-a462-f83037c369bf">
