### PR TITLE
NFT 메타데이터 모듈

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,23 +33,15 @@ async function bootstrap() {
     },
   );
 
-  // app.useStaticAssets(join(__dirname, '..', 'public'));
   app.setBaseViewsDir('./views');
   app.setViewEngine('hbs');
 
-  // useContainer(app.select(MainModule), { fallbackOnErrors: true });
   const isProduction = ConfigService.isProduction();
   const port = ConfigService.getConfig().PORT;
 
   app.setGlobalPrefix(ConfigService.getConfig().API_VERSION, {
     exclude: [
-      { path: '/health', method: RequestMethod.GET },
-      { path: '/maintenance', method: RequestMethod.GET },
-      { path: '/version', method: RequestMethod.GET },
-    ],
-  });
-  app.setGlobalPrefix(ConfigService.getConfig().API_VERSION, {
-    exclude: [
+      { path: '/metadata.*', method: RequestMethod.GET },
       { path: '/health', method: RequestMethod.GET },
       { path: '/maintenance', method: RequestMethod.GET },
       { path: '/version', method: RequestMethod.GET },

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ async function bootstrap() {
 
   app.setGlobalPrefix(ConfigService.getConfig().API_VERSION, {
     exclude: [
-      { path: '/metadata.*', method: RequestMethod.GET },
+      { path: '/metadata(.*)', method: RequestMethod.GET },
       { path: '/health', method: RequestMethod.GET },
       { path: '/maintenance', method: RequestMethod.GET },
       { path: '/version', method: RequestMethod.GET },

--- a/src/module/main.module.ts
+++ b/src/module/main.module.ts
@@ -21,6 +21,7 @@ import { MailModule } from './email/email.module';
 import { QuestModule } from './quest/quest.module';
 import { ZoneModule } from './zone/zone.module';
 import { CloudStorageModule } from './cloudStorage/cloudStorage.module';
+import { MetadataModule } from './metadata/metadata.module';
 
 @Module({
   imports: [
@@ -50,6 +51,7 @@ import { CloudStorageModule } from './cloudStorage/cloudStorage.module';
     QuestModule,
     ZoneModule,
     CloudStorageModule,
+    MetadataModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/src/module/metadata/dto/metadata.dto.ts
+++ b/src/module/metadata/dto/metadata.dto.ts
@@ -1,0 +1,25 @@
+import { IsDefined, IsNumber, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class MetadataAttribute {
+  display_type?: string;
+  trait_type: string;
+  value: number | string;
+}
+
+export class OpenseaStandardMetadata {
+  name?: string;
+  image?: string;
+  description?: string;
+  attributes: Array<MetadataAttribute>;
+}
+
+export class GetMetadataRequest {
+  @IsNumber()
+  @Type(() => Number)
+  public nftId: number;
+
+  @IsNumber()
+  @Type(() => Number)
+  public tokenId: number;
+}

--- a/src/module/metadata/metadata.controller.ts
+++ b/src/module/metadata/metadata.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
+import { GetMetadataRequest, OpenseaStandardMetadata } from './dto/metadata.dto';
+import { MetadataService } from './metadata.service';
+
+@Controller('metadata')
+export class MetadataController {
+  constructor(
+    private readonly metadataService: MetadataService,
+  ) { }
+
+  @ApiExcludeEndpoint()
+  @Get(':nftId/:tokenId')
+  async getMetadata(@Param() dto: GetMetadataRequest): Promise<OpenseaStandardMetadata | null> {
+
+    const result = await this.metadataService.getMetadata(dto);
+    return result;
+  }
+
+}

--- a/src/module/metadata/metadata.module.ts
+++ b/src/module/metadata/metadata.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { MetadataController } from './metadata.controller';
+import { MetadataService } from './metadata.service';
+import { RepositoryModule } from '../repository/repository.module';
+
+@Module({
+  imports: [RepositoryModule],
+  controllers: [MetadataController],
+  providers: [MetadataService],
+})
+export class MetadataModule {}

--- a/src/module/metadata/metadata.service.ts
+++ b/src/module/metadata/metadata.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import {
+  GetMetadataRequest,
+  OpenseaStandardMetadata,
+} from './dto/metadata.dto';
+import { NftMetadataRepositoryService } from './../repository/service/nft-metadata.repository.service';
+
+@Injectable()
+export class MetadataService {
+  constructor(
+    private readonly nftMetadataRepositoryService: NftMetadataRepositoryService,
+  ) {}
+
+  async getMetadata(
+    dto: GetMetadataRequest,
+  ): Promise<OpenseaStandardMetadata | null> {
+    const metadata =
+      await this.nftMetadataRepositoryService.findMetadataByTokenId(
+        dto.nftId,
+        dto.tokenId,
+      );
+    return metadata;
+  }
+}

--- a/src/module/repository/entity/nft-metadata.entity.ts
+++ b/src/module/repository/entity/nft-metadata.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { NftEntity } from './nft.entity';
+import { OpenseaStandardMetadata } from 'src/module/metadata/dto/metadata.dto';
+
+@Entity('nft_metadata')
+export class NftMetadataEntity {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column('int')
+  nftId: number;
+
+  @Column('int')
+  tokenId: number;
+
+  @Column('jsonb', { nullable: true })
+  metadata: OpenseaStandardMetadata;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+
+  @ManyToOne(() => NftEntity, {
+    onDelete: 'NO ACTION',
+    onUpdate: 'NO ACTION',
+  })
+  @JoinColumn({ name: 'nft_id' })
+  nft: NftEntity;
+}

--- a/src/module/repository/entity/nft.entity.ts
+++ b/src/module/repository/entity/nft.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('nft')
+export class NftEntity {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column('varchar')
+  network: string;
+
+  @Column('varchar')
+  address: string;
+
+  @Column('varchar')
+  name: string;
+
+  @Column('varchar')
+  symbol: string;
+
+  @Column('boolean')
+  isTokenIdAutoIncremented: boolean;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/src/module/repository/entity/nft.entity.ts
+++ b/src/module/repository/entity/nft.entity.ts
@@ -5,14 +5,15 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { BlockchainNetworks } from '../enum/nft.enum';
 
 @Entity('nft')
 export class NftEntity {
   @PrimaryGeneratedColumn('increment')
   id: number;
 
-  @Column('varchar')
-  network: string;
+  @Column('enum', { enum: BlockchainNetworks })
+  network: BlockchainNetworks;
 
   @Column('varchar')
   address: string;

--- a/src/module/repository/enum/nft.enum.ts
+++ b/src/module/repository/enum/nft.enum.ts
@@ -1,0 +1,3 @@
+export enum BlockchainNetworks {
+  POLYGON = 'polygon',
+}

--- a/src/module/repository/repository.module.ts
+++ b/src/module/repository/repository.module.ts
@@ -10,6 +10,9 @@ import { QuestEntity } from './entity/quest.entity';
 import { LogQuestEntity } from './entity/log-quest.entity';
 import { ZoneEntity } from './entity/zone.entity';
 import { ZoneRepositoryService } from './service/zone.repository.service';
+import { NftMetadataRepositoryService } from './service/nft-metadata.repository.service';
+import { NftEntity } from './entity/nft.entity';
+import { NftMetadataEntity } from './entity/nft-metadata.entity';
 
 @Module({
   imports: [
@@ -20,6 +23,8 @@ import { ZoneRepositoryService } from './service/zone.repository.service';
       QuestEntity,
       LogQuestEntity,
       ZoneEntity,
+      NftEntity,
+      NftMetadataEntity,
     ]),
   ],
   providers: [
@@ -27,12 +32,14 @@ import { ZoneRepositoryService } from './service/zone.repository.service';
     SupportRepositoryService,
     QuestRepositoryService,
     ZoneRepositoryService,
+    NftMetadataRepositoryService,
   ],
   exports: [
     UserRepositoryService,
     SupportRepositoryService,
     QuestRepositoryService,
     ZoneRepositoryService,
+    NftMetadataRepositoryService,
   ],
 })
 export class RepositoryModule {}

--- a/src/module/repository/service/nft-metadata.repository.service.ts
+++ b/src/module/repository/service/nft-metadata.repository.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { NftMetadataEntity } from '../entity/nft-metadata.entity';
+import { OpenseaStandardMetadata } from 'src/module/metadata/dto/metadata.dto';
+
+@Injectable()
+export class NftMetadataRepositoryService {
+  constructor(
+    @InjectRepository(NftMetadataEntity)
+    private nftMetadataRepository: Repository<NftMetadataEntity>,
+  ) {}
+
+  async findMetadataByTokenId(
+    nftId: number,
+    tokenId: number,
+  ): Promise<OpenseaStandardMetadata> {
+    const nftMetadata = await this.nftMetadataRepository.findOneBy({
+      nftId,
+      tokenId,
+    });
+
+    return nftMetadata?.metadata;
+  }
+}


### PR DESCRIPTION
### NFT 메타데이터 DB
<img width="495" alt="image" src="https://github.com/Duksung-Kkureogi/duzzle-be/assets/158791917/34706e33-86ca-44c9-ae95-7233a2e059d2">

#### nft  테이블
- network: 네트워크 타입 (현재는 폴리곤 네트워크만 지원)
- address: 토큰 컨트랙트 주소
- name: 토큰 이름
- symbol: 토큰 심볼
- is_token_id_auto_incremented: 토큰아이디가 순차적으로 증가하는지

예시) 
- 재료 아이템 NFT
        => 발행될때 토큰아이디 1씩 증가

- 설계도면 아이템, 퍼즐조각 NFT: 
        => 위치별로 이미지나 쓰임이 다르므로 특정 토큰아이디부여

#### nft_metadata 테이블
: nft 테이블에서 정의한  NFT 들의 메타데이터를 정의 


메타데이터 포맷: https://docs.opensea.io/docs/metadata-standards

### 각 NFT 별 메타데이터 조회 API
더즐 프론트엔드가 호출하는 API가 아니어서 version prefix(`/v1`) 생략하고, 스웨거에서도 제외했습니다!