### PR TITLE
프로필 이미지 저장 위치 변경

### DIFF
--- a/src/constant/image.ts
+++ b/src/constant/image.ts
@@ -1,2 +1,2 @@
 export const USER_PROFILE_DEFAULT_IMG: string =
-  'https://duzzle-s3-bucket.s3.ap-northeast-2.amazonaws.com/default.png';
+  'https://duzzle-s3-bucket.s3.ap-northeast-2.amazonaws.com/user/default.png';

--- a/src/constant/image.ts
+++ b/src/constant/image.ts
@@ -1,2 +1,2 @@
 export const USER_PROFILE_DEFAULT_IMG: string =
-  'https://duzzle-s3-bucket.s3.ap-northeast-2.amazonaws.com/user/default.png';
+  'https://duzzle-s3-bucket.s3.ap-northeast-2.amazonaws.com/user/profile_default.png';

--- a/src/module/auth/decorators/authenticated-user.decorator.ts
+++ b/src/module/auth/decorators/authenticated-user.decorator.ts
@@ -8,8 +8,6 @@ export const AuthenticatedUser = createParamDecorator(
     const request = ctx.switchToHttp().getRequest();
     const user: UserEntity | undefined = request[REQUEST_USER_KEY];
 
-    return plainToInstance(UserEntity, user, {
-      excludeExtraneousValues: true,
-    });
+    return plainToInstance(UserEntity, user);
   },
 );

--- a/src/module/user/user.service.ts
+++ b/src/module/user/user.service.ts
@@ -76,7 +76,7 @@ export class UserService {
       const imageName = uuid();
       const ext = file.originalname.split('.').pop();
       imageUrl = await this.cloudStorageService.uploadFile(
-        `${imageName}.${ext}`,
+        `user/${imageName}.${ext}`,
         file,
         ext,
       );
@@ -84,7 +84,7 @@ export class UserService {
 
     const user = await this.userRepositoryService.getUserById(userId);
     if (user.image && user.image !== USER_PROFILE_DEFAULT_IMG) {
-      await this.cloudStorageService.deleteFile(user.image.split('/').pop());
+      await this.cloudStorageService.deleteFile(`user/${user.image.split('/').pop()}`);
     }
 
     await this.userRepositoryService.updateUser({


### PR DESCRIPTION
### 1. 프로필 이미지 저장 위치 : duzzle-s3-bucket/user
### 2. 프로필 기본 이미지 이름 변경 : default.png -> profile_default.png

이미 DB에 default.png 주소가 저장되어 있는 경우, 저장소에서 기본 이미지가 삭제되는 상황 발생 
-> 기본 이미지 이름 변경함으로써 해결