### PR TITLE
트랜잭션 수집 스케줄러 보완

### DIFF
--- a/src/module/blockchain/blockchain.core.service.ts
+++ b/src/module/blockchain/blockchain.core.service.ts
@@ -15,7 +15,6 @@ import {
   MostRecentBlock,
 } from './dto/blockchain.dto';
 import { ContractKey } from '../repository/enum/contract.enum';
-import { LogProvider } from 'src/provider/log.provider';
 
 @Injectable()
 export class BlockchainCoreService {
@@ -84,13 +83,6 @@ export class BlockchainCoreService {
       topics: dto.topics,
     };
     const logs = await this.providerForCollectingTxLogs.getLogs(filter);
-    LogProvider.info(
-      'getLogs',
-      {
-        filter,
-      },
-      BlockchainCoreService.name,
-    );
 
     return logs;
   }

--- a/src/module/blockchain/blockchain.core.service.ts
+++ b/src/module/blockchain/blockchain.core.service.ts
@@ -20,8 +20,10 @@ import { LogProvider } from 'src/provider/log.provider';
 @Injectable()
 export class BlockchainCoreService {
   private readonly provider: ethers.JsonRpcProvider;
+  private readonly providerForCollectingTxLogs: ethers.JsonRpcProvider;
   private readonly signer: ethers.Wallet;
   private readonly rpcUrl: string;
+  private readonly rpcUrlForCollectingTxLogs: string;
 
   constructor(
     private readonly configService: ConfigService,
@@ -32,7 +34,13 @@ export class BlockchainCoreService {
     this.rpcUrl = this.configService.get<string>(
       'BLOCKCHAIN_POLYGON_RPC_ENDPOINT',
     );
+    this.rpcUrlForCollectingTxLogs = this.configService.get<string>(
+      'BLOCKCHAIN_POLYGON_RPC_ENDPOINT_FOR_TX_LOGS',
+    );
     this.provider = new ethers.JsonRpcProvider(this.rpcUrl);
+    this.providerForCollectingTxLogs = new ethers.JsonRpcProvider(
+      this.rpcUrlForCollectingTxLogs,
+    );
     this.signer = new ethers.Wallet(process.env.OWNER_PK_AMOY, this.provider);
   }
 
@@ -75,7 +83,7 @@ export class BlockchainCoreService {
       address: dto.contractAddress,
       topics: dto.topics,
     };
-    const logs = await this.provider.getLogs(filter);
+    const logs = await this.providerForCollectingTxLogs.getLogs(filter);
     LogProvider.info(
       'getLogs',
       {

--- a/src/module/cache/enum/cache.enum.ts
+++ b/src/module/cache/enum/cache.enum.ts
@@ -1,7 +1,6 @@
 export enum RedisKey {
   EditUserName = 'edit_username',
   transactionCollectionInProgress = 'tx_collection_in_progress',
-  LastSyncedBlock = 'last_synced_block',
   AcidRainScore = 'quest:acidrain:score',
 }
 

--- a/src/module/cache/enum/cache.enum.ts
+++ b/src/module/cache/enum/cache.enum.ts
@@ -1,5 +1,6 @@
 export enum RedisKey {
   EditUserName = 'edit_username',
+  transactionCollectionInProgress = 'tx_collection_in_progress',
   LastSyncedBlock = 'last_synced_block',
   AcidRainScore = 'quest:acidrain:score',
 }

--- a/src/module/config/Configuration.ts
+++ b/src/module/config/Configuration.ts
@@ -117,6 +117,12 @@ export class EnvironmentVariables {
   @Expose()
   readonly BLOCKCHAIN_POLYGON_RPC_ENDPOINT: string;
 
+  // RPC URL for Collecting Tx Logs Schdeuler
+  @IsNotEmpty()
+  @IsString()
+  @Expose()
+  readonly BLOCKCHAIN_POLYGON_RPC_ENDPOINT_FOR_TX_LOGS: string;
+
   // In-momory DB
   @IsNotEmpty()
   @IsString()

--- a/src/module/scheduler/scheduler.module.ts
+++ b/src/module/scheduler/scheduler.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { RepositoryModule } from '../repository/repository.module';
-import { SchedulerService } from './scheduler.service';
+import { TransactionCollectionScheduler } from './transaction-collection.scheduler.service';
 import { ScheduleModule } from '@nestjs/schedule';
 import { BlockchainModule } from '../blockchain/blockchain.module';
 import { CacheModule } from '../cache/cache.module';
@@ -12,6 +12,6 @@ import { CacheModule } from '../cache/cache.module';
     BlockchainModule,
     CacheModule,
   ],
-  providers: [SchedulerService],
+  providers: [TransactionCollectionScheduler],
 })
 export class SchedulerModule {}

--- a/src/module/scheduler/scheduler.service.ts
+++ b/src/module/scheduler/scheduler.service.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from './../config/config.service';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ethers } from 'ethers';
@@ -27,12 +28,19 @@ export class SchedulerService {
 
     @Inject(CacheService)
     private readonly memory: CacheService,
+
+    private readonly configService: ConfigService,
   ) {}
 
   // @Cron(CronExpression.EVERY_MINUTE, {
   //   timeZone: 'UTC',
   // })
   async collectBlockchainTransaction() {
+    const isLocal = this.configService.isLocal();
+    if (isLocal) {
+      return;
+    }
+
     // 블록체인 네트워크의 최신 블록 가져오기
     const latestBlock =
       await this.blockchainCoreService.getLatestBlockNumberHex();

--- a/src/module/scheduler/transaction-collection.scheduler.service.ts
+++ b/src/module/scheduler/transaction-collection.scheduler.service.ts
@@ -15,6 +15,7 @@ import { ContractKey, ContractType } from '../repository/enum/contract.enum';
 @Injectable()
 export class TransactionCollectionScheduler {
   private readonly MAX_BLOCK_RANGE = 2_000;
+  private readonly MAX_REQUESTS_PER_SECOND = 10;
 
   constructor(
     @Inject(BlockchainCoreService)
@@ -32,16 +33,17 @@ export class TransactionCollectionScheduler {
     private readonly configService: ConfigService,
   ) {}
 
-  @Cron(CronExpression.EVERY_MINUTE, {
+  @Cron(CronExpression.EVERY_10_SECONDS, {
     timeZone: 'UTC',
   })
   async collectBlockchainTransaction() {
     const isLocal = this.configService.isLocal();
     if (isLocal) {
-      return;
+      // return;
     }
 
     if (await this.isSchedulerRunning()) {
+      console.log('Scheduler is already running');
       return;
     }
 
@@ -50,15 +52,19 @@ export class TransactionCollectionScheduler {
     // 블록체인 네트워크의 최신 블록 가져오기
     const latestBlock =
       await this.blockchainCoreService.getLatestBlockNumberHex();
+    console.log('latestBlock: ', latestBlock);
 
+    console.time('collectBlockchainTransaction');
     try {
       // 마지막으로 수집된 블록넘버 가져오기
       const lastSyncedBlock: number = await this.getLastSyncedBlock();
+      console.log(lastSyncedBlock);
 
       const blockRange = parseInt(latestBlock, 16) - lastSyncedBlock;
       if (blockRange < 1) {
         return;
       }
+      console.log('blockRange: ', blockRange);
 
       let collectedLogs: ethers.Log[] = [];
       const nftContracts = await this.nftRepositoryService.findContractsByType(
@@ -80,13 +86,24 @@ export class TransactionCollectionScheduler {
             topics: [EventTopic.transfer],
           });
         }
-        for (let i: number = 0; i < collectLogDtos.length; i++) {
-          let logs: ethers.Log[] = await this.blockchainCoreService.getLogs(
-            collectLogDtos[i],
-          );
 
-          collectedLogs = [...collectedLogs, ...logs];
-          await new Promise((resolve) => setTimeout(resolve, 100));
+        console.log('collectLogDto length: ', collectLogDtos.length);
+        // Alchemy API 요청 제한을 고려하여 요청을 분할하여 처리
+        if (collectLogDtos.length < this.MAX_REQUESTS_PER_SECOND) {
+          collectedLogs = (
+            await Promise.all(
+              collectLogDtos.map((e) => this.blockchainCoreService.getLogs(e)),
+            )
+          ).flat();
+        } else {
+          for (let i: number = 0; i < collectLogDtos.length; i++) {
+            let logs: ethers.Log[] = await this.blockchainCoreService.getLogs(
+              collectLogDtos[i],
+            );
+
+            collectedLogs = [...collectedLogs, ...logs];
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
         }
       } else {
         collectedLogs = await this.blockchainCoreService.getLogs({
@@ -109,13 +126,12 @@ export class TransactionCollectionScheduler {
         ),
         this.blockchainTransactionService.upsertTransactionLogs(txLogsToUpsert),
       ]);
-
-      await this.setLastSyncedBlock(latestBlock);
     } catch (error) {
       Logger.error(error.stack);
       Logger.error(error);
     } finally {
       await this.setEndFlag();
+      console.timeEnd('collectBlockchainTransaction');
     }
   }
 
@@ -133,28 +149,17 @@ export class TransactionCollectionScheduler {
 
   private async getLastSyncedBlock() {
     // 마지막으로 수집된 블록넘버 가져오기
-    let lastSyncedBlock: number = parseInt(
-      await this.memory.find(RedisKey.LastSyncedBlock),
-    );
-    lastSyncedBlock = 7695665;
-
+    let lastSyncedBlock =
+      await this.blockchainTransactionService.findLastSyncedBlock();
     if (!lastSyncedBlock) {
-      const _lastSyncedBlock =
-        await this.blockchainTransactionService.findLastSyncedBlock();
-      if (!_lastSyncedBlock) {
-        const birthBlockOfContract = (
-          await this.nftRepositoryService.findContractByKey(
-            ContractKey.PLAY_DUZZLE,
-          )
-        ).birthBlock;
-        lastSyncedBlock = birthBlockOfContract;
-      }
+      const birthBlockOfContract = (
+        await this.nftRepositoryService.findContractByKey(
+          ContractKey.PLAY_DUZZLE,
+        )
+      ).birthBlock;
+      lastSyncedBlock = birthBlockOfContract;
+    } else {
+      return lastSyncedBlock;
     }
-
-    return lastSyncedBlock;
-  }
-
-  private async setLastSyncedBlock(latestBlock: string) {
-    await this.memory.set(RedisKey.LastSyncedBlock, latestBlock);
   }
 }


### PR DESCRIPTION
**문제**: 기존에 사용하던 서비스(Alchemy) API 요청 제한(1초에 최대 5건) 으로
NFT 소유자 동기화가 빠르지 않았음

**해결**: 트랜잭션 수집용으로 새로운 서비스(Infura) 이용 (1초에 최대 10건)

추가 수정 사항
- 로컬 환경에서는 스케줄러 작동 안하도록 수정
- 스케줄러 5초에 한 번씩 동작
- 5초가 넘었을 경우 새 작업을 시작하지 않도록 수정


- 2000블록씩 나눠서 10건이 넘으면 0.1초기다렸다가 다음 요청 
- 10건 이하면 동시에 처리(Promise.all()) <Infura API 제한 고려 >