### PR TITLE
Feat: 현재 시즌 랭킹 API

### DIFF
--- a/src/module/main.module.ts
+++ b/src/module/main.module.ts
@@ -32,6 +32,7 @@ import { SchedulerModule } from './scheduler/scheduler.module';
 import { ItemModule } from './item/item.module';
 import { WebSocketModule } from 'src/module/websocket/websocket.module';
 import { WebSocketExceptionFilter } from 'src/filter/websocket-exception-filter';
+import { RankingsModule } from './rankings/rankings.module';
 
 @Module({
   imports: [
@@ -75,6 +76,7 @@ import { WebSocketExceptionFilter } from 'src/filter/websocket-exception-filter'
     SchedulerModule,
     ItemModule,
     WebSocketModule,
+    RankingsModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/src/module/puzzle/puzzle.service.ts
+++ b/src/module/puzzle/puzzle.service.ts
@@ -11,6 +11,7 @@ import {
 } from './user.puzzle.dto';
 import { PaginatedList } from 'src/dto/response.dto';
 import { ContractKey } from '../repository/enum/contract.enum';
+import { PuzzlePieceEntity } from '../repository/entity/puzzle-piece.entity';
 
 @Injectable()
 export class PuzzleService {
@@ -19,7 +20,17 @@ export class PuzzleService {
     private readonly nftRepositoryService: NftRepositoryService,
   ) {}
 
-  async getAllSeasons() {
+  async getNftHoldersBySeasonId(
+    seasonId: number,
+  ): Promise<Pick<PuzzlePieceEntity, 'holerWalletAddress' | 'holderName'>[]> {
+    return this.puzzleRepositoryService.getNftHoldersBySeasonId(seasonId);
+  }
+
+  async getThisSeason(): Promise<SeasonEntity> {
+    return this.puzzleRepositoryService.getThisSeason();
+  }
+
+  async getAllSeasons(): Promise<SeasonEntity[]> {
     return this.puzzleRepositoryService.getAllSeasons();
   }
 

--- a/src/module/rankings/dto/rankings.dto.ts
+++ b/src/module/rankings/dto/rankings.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Rankings {
+  @ApiProperty()
+  rank: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  walletAddress: string;
+
+  @ApiProperty({ description: '보유한 퍼즐 NFT 개수' })
+  nftHoldings: number;
+
+  @ApiProperty({ description: '보유한 퍼즐 NFT 개수 비율' })
+  nftHoldingsPercentage: number;
+}

--- a/src/module/rankings/rankings.controller.ts
+++ b/src/module/rankings/rankings.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, HttpStatus } from '@nestjs/common';
+
+import { ResponsesListDto } from 'src/dto/responses-list.dto';
+import { Rankings } from './dto/rankings.dto';
+import { ApiDescription } from 'src/decorator/api-description.decorator';
+import { RankingsService } from './rankings.service';
+
+@Controller('rankings')
+export class RankingsController {
+  constructor(private readonly rankingsService: RankingsService) {}
+
+  @ApiDescription({
+    tags: 'Rankings',
+    summary: '현재 시즌 퍼즐 조각 잠금해제 랭킹 조회',
+    listResponse: {
+      status: HttpStatus.OK,
+      schema: Rankings,
+    },
+  })
+  @Get('current-season')
+  async getCurrentSeasonRankings(): Promise<ResponsesListDto<Rankings>> {
+    const rankings = await this.rankingsService.getCurrentSeasonRankings();
+
+    return new ResponsesListDto(rankings);
+  }
+}

--- a/src/module/rankings/rankings.module.ts
+++ b/src/module/rankings/rankings.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PuzzleModule } from '../puzzle/puzzle.module';
+import { RankingsController } from './rankings.controller';
+import { RankingsService } from './rankings.service';
+
+@Module({
+  imports: [PuzzleModule],
+  providers: [RankingsService],
+  controllers: [RankingsController],
+})
+export class RankingsModule {}

--- a/src/module/rankings/rankings.service.ts
+++ b/src/module/rankings/rankings.service.ts
@@ -1,0 +1,75 @@
+import { Inject } from '@nestjs/common';
+import { PuzzleService } from '../puzzle/puzzle.service';
+import { Rankings } from './dto/rankings.dto';
+
+export class RankingsService {
+  constructor(
+    @Inject(PuzzleService) private readonly puzzleService: PuzzleService,
+  ) {}
+
+  async getCurrentSeasonRankings(): Promise<Rankings[]> {
+    const thisSeason = await this.puzzleService.getThisSeason();
+    console.log('thisSeason', thisSeason);
+    const getNftHoldingsPercentage = (nftholdings: number) => {
+      return (nftholdings / thisSeason.totalPieces) * 100;
+    };
+
+    const nftHolders = await this.puzzleService.getNftHoldersBySeasonId(
+      thisSeason.id,
+    );
+
+    console.log('nftHolders', nftHolders);
+
+    // address, name 으로 groupBy 해서 퍼즐 NFT 개수 카운트
+    // -> 내림차순으로 정렬(동일 개수일 경우 순위 동일)
+    const predata: Omit<Rankings, 'rank'>[] = nftHolders.reduce(
+      (acc, cur) => {
+        const index = acc.findIndex(
+          (e: Rankings) => e.walletAddress === cur.holerWalletAddress,
+        );
+        if (index < 0) {
+          acc.push({
+            walletAddress: cur.holerWalletAddress,
+            name: cur.holderName || 'Anonymous',
+            nftHoldings: 1,
+            nftHoldingsPercentage: getNftHoldingsPercentage(1),
+          });
+        } else {
+          acc[index].nftHoldings += 1;
+          acc[index].nftHoldingsPercentage = getNftHoldingsPercentage(
+            acc[index].nftHoldings,
+          );
+        }
+
+        return acc;
+      },
+      <Omit<Rankings, 'rank'>[]>[],
+    );
+
+    // nftHoldings 기준으로 내림차순 정렬
+    const sorted = predata.sort((a, b) => {
+      return b.nftHoldings - a.nftHoldings;
+    });
+
+    const rankings = sorted.reduce((acc, current, index) => {
+      let rank: number;
+
+      if (index === 0) {
+        rank = 1;
+      } else if (current.nftHoldings === acc[index - 1].nftHoldings) {
+        rank = acc[index - 1].rank;
+      } else {
+        rank = acc[index - 1].rank + 1;
+      }
+
+      acc.push({
+        ...current,
+        rank,
+      });
+
+      return acc;
+    }, [] as Rankings[]);
+
+    return rankings;
+  }
+}

--- a/src/module/repository/service/puzzle.repository.service.ts
+++ b/src/module/repository/service/puzzle.repository.service.ts
@@ -22,6 +22,23 @@ export class PuzzleRepositoryService {
     private userRepositoryService: UserRepositoryService,
   ) {}
 
+  async getNftHoldersBySeasonId(
+    seasonId: number,
+  ): Promise<Pick<PuzzlePieceEntity, 'holerWalletAddress' | 'holderName'>[]> {
+    return this.puzzlePieceRepository
+      .createQueryBuilder('pp')
+      .select('pp.holderName', 'holderName')
+      .addSelect('pp.holerWalletAddress', 'holerWalletAddress')
+      .leftJoin('pp.seasonZone', 'sz')
+      .where('sz.seasonId = :seasonId', { seasonId })
+      .andWhere('pp.minted = true')
+      .getRawMany();
+  }
+
+  async getThisSeason(): Promise<SeasonEntity> {
+    return this.seasonRepository.findOne({ where: {}, order: { id: 'DESC' } });
+  }
+
   async getAllSeasons(): Promise<SeasonEntity[]> {
     return await this.seasonRepository.find();
   }


### PR DESCRIPTION
<img width="281" alt="image" src="https://github.com/user-attachments/assets/05a64044-aa78-48b1-b93a-2d91c433e247">

## 현재 시즌 퍼즐 조각 잠금해제 랭킹 조회 API
**GET** **_/v1/rankings/current-season_**
- 로그인 안해도 조회 가능
- 단, 각 순위의 유저 프로필 정보 조회는 `유저가 설정한 프로필 공개 여부에 따라` 제한될 수 있음
- NFT 수 동일한 경우 동일 순위(1등 > 1등 > 2등 ...)
<img width="554" alt="image" src="https://github.com/user-attachments/assets/7f4cedcc-0e77-44fd-a578-c9004b09d8b3">

-> (클라이언트 측) 나의 순위 판단 = 현재 로그인하여 저장하고 있는 유저 지갑주소와 순위의 지갑주소를 비교


예시 응답
```json
{
  "result": true,
  "data": {
    "total": 1,
    "list": [
      {
        "walletAddress": "0x789", // 지갑 주소
        "name": "bb", // 유저 이름
        "nftHoldings": 3, // NFT 보유량
        "nftHoldingsPercentage": 15, // NFT 보유율
        "rank": 1 // 순위
      },
      {
        "walletAddress": "0x123...",
        "name": "ㅎㅎ",
        "nftHoldings": 3,
        "nftHoldingsPercentage": 15,
        "rank": 1
      },
      {
        "walletAddress": "0x456...",
        "name": "haha",
        "nftHoldings": 1,
        "nftHoldingsPercentage": 5,
        "rank": 2
      }
    ]
  }
}
```