### PR TITLE
다른 유저 프로필 API

### DIFF
--- a/src/constant/exception.ts
+++ b/src/constant/exception.ts
@@ -15,6 +15,10 @@ export enum ExceptionCode {
   InvalidRefreshToken = 'INVALID_REFRESH_TOKEN',
   InvalidAddress = 'INVALID_ADDRESS',
   InvalidLoginInfo = 'INVALID_LOGIN_INFO',
+  LoginRequired = 'LOGIN_REQUIRED',
+
+  // 403 (Forbidden)
+  ProfileAccessDenied = 'PROFILE_ACCESS_DENIED',
 
   // 404 (Not Found)
   ContentNotFound = 'CONTENT_NOT_FOUND',
@@ -49,4 +53,6 @@ export const CodeToStatus: {
   [ExceptionCode.InvalidFilenameCharacters]: HttpStatus.BAD_REQUEST,
   [ExceptionCode.InvalidRefreshToken]: HttpStatus.UNAUTHORIZED,
   [ExceptionCode.PageNotFound]: HttpStatus.NOT_FOUND,
+  [ExceptionCode.LoginRequired]: HttpStatus.UNAUTHORIZED,
+  [ExceptionCode.ProfileAccessDenied]: HttpStatus.FORBIDDEN,
 };

--- a/src/module/auth/auth.controller.ts
+++ b/src/module/auth/auth.controller.ts
@@ -42,8 +42,8 @@ export class AuthController {
   @ApiDescription({
     tags: 'Auth',
     summary: '로그인',
-    auth: { 
-      type: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerLoginIdToken,
       required: true,
     },
     dataResponse: {

--- a/src/module/auth/auth.controller.ts
+++ b/src/module/auth/auth.controller.ts
@@ -42,7 +42,10 @@ export class AuthController {
   @ApiDescription({
     tags: 'Auth',
     summary: '로그인',
-    auth: AuthorizationToken.BearerLoginIdToken,
+    auth: { 
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: LoginResponse,

--- a/src/module/item/item.controller.ts
+++ b/src/module/item/item.controller.ts
@@ -22,7 +22,10 @@ export class ItemController {
   @UseGuards(AuthGuard)
   @ApiDescription({
     tags: 'Item',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     summary: '유저 보유 아이템 NFT 현황(현재 시즌만 해당)',
     listResponse: {
       status: HttpStatus.OK,

--- a/src/module/puzzle/puzzle.controller.ts
+++ b/src/module/puzzle/puzzle.controller.ts
@@ -81,7 +81,10 @@ export class PuzzleController {
 
   @ApiDescription({
     tags: 'Puzzle',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     summary: '유저 보유 퍼즐 조각 NFT 목록',
     listResponse: {
       status: HttpStatus.OK,
@@ -103,7 +106,10 @@ export class PuzzleController {
   @UseGuards(AuthGuard)
   @ApiDescription({
     tags: 'Puzzle',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     summary: '유저 보유 퍼즐 조각 NFT 상세',
     dataResponse: {
       status: HttpStatus.OK,

--- a/src/module/quest/rest/quest.controller.ts
+++ b/src/module/quest/rest/quest.controller.ts
@@ -35,8 +35,10 @@ export class QuestController {
   @ApiDescription({
     tags: 'Quest',
     summary: '랜덤 퀘스트 시작하기',
-    description: '유저가 등록한 1:1 문의 목록, 마지막 수정 시간 내림차순 정렬',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: StartRandomQuestResponse,
@@ -56,7 +58,10 @@ export class QuestController {
   @ApiDescription({
     tags: 'Quest',
     summary: '퀘스트 결과',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: true,

--- a/src/module/repository/dto/user.dto.ts
+++ b/src/module/repository/dto/user.dto.ts
@@ -1,4 +1,4 @@
-import { LoginType } from '../enum/user.enum';
+import { LoginType, ProfileType } from '../enum/user.enum';
 
 export class InsertUserDto {
   loginType: LoginType;
@@ -10,4 +10,5 @@ export class UpdateUserDto {
   id: number;
   name?: string;
   image?: string;
+  profileType?: ProfileType;
 }

--- a/src/module/repository/entity/user.entity.ts
+++ b/src/module/repository/entity/user.entity.ts
@@ -1,5 +1,5 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
-import { LoginType } from '../enum/user.enum';
+import { LoginType, ProfileType } from '../enum/user.enum';
 import { BaseEntity } from './base.entity';
 import { USER_PROFILE_DEFAULT_IMG } from 'src/constant/image';
 
@@ -28,6 +28,9 @@ export class UserEntity extends BaseEntity {
 
   @Column('varchar', { nullable: true, default: USER_PROFILE_DEFAULT_IMG })
   image: string;
+
+  @Column('enum', { enum: ProfileType, default: ProfileType.Private })
+  profileType: ProfileType;
 
   @Column('enum', {
     enum: UserStatus,

--- a/src/module/repository/enum/user.enum.ts
+++ b/src/module/repository/enum/user.enum.ts
@@ -8,3 +8,9 @@ export enum LoginType {
   Facebook = 'FACEBOOK',
   Twitter = 'TWITTER',
 }
+
+export enum ProfileType {
+  Public = 'PUBLIC',
+  Private = 'PRIVATE',
+  None = 'NONE',
+}

--- a/src/module/repository/service/user.repository.service.ts
+++ b/src/module/repository/service/user.repository.service.ts
@@ -24,6 +24,15 @@ export class UserRepositoryService {
     return user;
   }
 
+  async getUserByWalletAddress(walletAddress: string): Promise<UserEntity> {
+    const user = await this.userRepository.findOneBy({ walletAddress });
+    if (!user) {
+      throw new ContentNotFoundError('user', walletAddress);
+    }
+
+    return user;
+  }
+
   async findUserById(id: number): Promise<UserEntity> {
     const user = await this.userRepository.findOneBy({ id });
 

--- a/src/module/support/support.controller.ts
+++ b/src/module/support/support.controller.ts
@@ -56,7 +56,10 @@ export class SupportController {
   @ApiDescription({
     tags: 'Support',
     summary: '1:1 문의 등록',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: true,
@@ -77,7 +80,10 @@ export class SupportController {
   @ApiDescription({
     tags: 'Support',
     summary: '1:1 문의 수정',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: true,
@@ -100,7 +106,10 @@ export class SupportController {
   @ApiDescription({
     tags: 'Support',
     summary: '1:1 문의 삭제',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: true,
@@ -123,7 +132,10 @@ export class SupportController {
     tags: 'Support',
     summary: '1:1 문의 목록',
     description: '유저가 등록한 1:1 문의 목록, 마지막 수정 시간 내림차순 정렬',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     listResponse: {
       status: HttpStatus.OK,
       schema: QnaResponse,
@@ -144,7 +156,10 @@ export class SupportController {
     tags: 'Support',
     summary: '특정 1:1 문의 조회',
     description: '유저가 등록한 1:1 문의 목록, 마지막 수정 시간 내림차순 정렬',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: QnaResponse,

--- a/src/module/user-story/user-story.controller.ts
+++ b/src/module/user-story/user-story.controller.ts
@@ -37,9 +37,12 @@ export class UserStoryController {
   @UseGuards(AuthGuard)
   @ApiDescription({
     tags: 'Story',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     summary: '유저 구역별 스토리 진행도 조회',
-    dataResponse: {
+    listResponse: {
       status: HttpStatus.OK,
       schema: StoryProgressResponse,
     },
@@ -57,9 +60,12 @@ export class UserStoryController {
   @UseGuards(AuthGuard)
   @ApiDescription({
     tags: 'Story',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     summary: '유저 특정 구역 스토리 진행도 조회',
-    dataResponse: {
+    listResponse: {
       status: HttpStatus.OK,
       schema: StoryProgressByZoneResponse,
     },
@@ -81,7 +87,10 @@ export class UserStoryController {
   @UseGuards(AuthGuard)
   @ApiDescription({
     tags: 'Story',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     summary: '유저 스토리별 진행도 수정',
     dataResponse: {
       status: HttpStatus.OK,

--- a/src/module/user/dto/user.dto.ts
+++ b/src/module/user/dto/user.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty, IntersectionType } from '@nestjs/swagger';
 import { Expose, plainToInstance } from 'class-transformer';
-import { IsNotEmpty, IsOptional } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsOptional } from 'class-validator';
 import { UserEntity } from 'src/module/repository/entity/user.entity';
+import { ProfileType } from 'src/module/repository/enum/user.enum';
 
 export class UserInfoResponse {
   @ApiProperty()
@@ -19,6 +20,10 @@ export class UserInfoResponse {
   @ApiProperty()
   @Expose()
   image: string;
+
+  @ApiProperty()
+  @Expose()
+  profileType: ProfileType;
 
   @ApiProperty()
   @Expose()
@@ -58,6 +63,12 @@ export class UpdateUserNameRequest {
   @ApiProperty()
   @IsNotEmpty()
   name: string;
+}
+
+export class UpdateUserProfileTypeRequest {
+  @ApiProperty({ type: 'enum', enum: ProfileType })
+  @IsEnum(ProfileType)
+  profileType: ProfileType;
 }
 
 export class ImageUploadDto {

--- a/src/module/user/user.controller.ts
+++ b/src/module/user/user.controller.ts
@@ -59,7 +59,10 @@ export class UserController {
     tags: 'User',
     summary: '유저 정보 조회',
     description: '로그인한 유저 정보 조회',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: UserProfileResponse,
@@ -82,7 +85,10 @@ export class UserController {
     private 프로필에 비로그인 유저 접근: LOGIN_REQUIRED
     none 프로필에 로그인/비로그인 유저 접근: PROFILE_ACCESS_DENIED
     `,
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: false,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: UserProfileResponse,
@@ -108,7 +114,10 @@ export class UserController {
   @ApiDescription({
     tags: 'User',
     summary: '유저 이름 변경',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     description: `
     이미 존재하는 이름일 경우 409 ALREADY_EXISTS\n
     ${RedisTTL.EditUserName / 1000} 초가 지나기 전에 이름을 바꾸는 경우\n
@@ -149,7 +158,10 @@ export class UserController {
   @ApiDescription({
     tags: 'User',
     summary: '유저 프로필 이미지 변경',
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: UserInfoResponse,
@@ -179,7 +191,10 @@ export class UserController {
     private: 로그인 유저만 열람 가능(기본값),
     none: 아무도 접근 불가
     `,
-    auth: AuthorizationToken.BearerUserToken,
+    auth: {
+      type: AuthorizationToken.BearerUserToken,
+      required: true,
+    },
     dataResponse: {
       status: HttpStatus.OK,
       schema: UserInfoResponse,

--- a/src/module/user/user.controller.ts
+++ b/src/module/user/user.controller.ts
@@ -17,7 +17,7 @@ import { ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
 
 import { ResponsesDataDto } from 'src/dto/responses-data.dto';
 import { AuthorizationToken } from 'src/constant/authorization-token';
-import { AuthGuard } from '../auth/auth.guard';
+import { AuthGuard, PublicOrAuthGuard } from '../auth/auth.guard';
 import {
   ImageUploadDto,
   UpdateUserNameRequest,
@@ -79,8 +79,8 @@ export class UserController {
     tags: 'User',
     summary: '다른 유저 정보 조회',
     description: `
-    private 프로필에 비로그인 유저 접근: ,
-    none 프로필에 로그인/비로그인 유저 접근: 
+    private 프로필에 비로그인 유저 접근: LOGIN_REQUIRED
+    none 프로필에 로그인/비로그인 유저 접근: PROFILE_ACCESS_DENIED
     `,
     auth: AuthorizationToken.BearerUserToken,
     dataResponse: {
@@ -89,6 +89,7 @@ export class UserController {
     },
     exceptions: [ContentNotFoundError, ProfileAccessDenied, LoginRequired],
   })
+  @UseGuards(PublicOrAuthGuard)
   @HttpCode(HttpStatus.OK)
   @Get(':walletAddress')
   async getOtherUserInfo(

--- a/src/module/user/user.controller.ts
+++ b/src/module/user/user.controller.ts
@@ -20,6 +20,7 @@ import { AuthGuard } from '../auth/auth.guard';
 import {
   ImageUploadDto,
   UpdateUserNameRequest,
+  UpdateUserProfileTypeRequest,
   UserInfoResponse,
   UserProfileResponse,
 } from './dto/user.dto';
@@ -37,6 +38,7 @@ import { ApiDescription } from 'src/decorator/api-description.decorator';
 import {
   InvalidFileNameCharatersError,
   InvalidFileNameExtensionError,
+  InvalidParamsError,
 } from 'src/types/error/application-exceptions/400-bad-request';
 
 @Controller({
@@ -132,6 +134,36 @@ export class UserController {
     @UploadedFile() file: Express.Multer.File,
   ): Promise<ResponsesDataDto<UserInfoResponse>> {
     const result = await this.userService.updateUserImage(user.id, file);
+
+    return new ResponsesDataDto(result);
+  }
+
+  @ApiDescription({
+    tags: 'User',
+    summary: '유저 프로필 공개여부 설정',
+    description: `
+    public: 비로그인, 로그인 유저 모두 열람 가능,
+    private: 로그인 유저만 열람 가능(기본값),
+    none: 아무도 접근 불가
+    `,
+    auth: AuthorizationToken.BearerUserToken,
+    dataResponse: {
+      status: HttpStatus.OK,
+      schema: UserInfoResponse,
+    },
+    exceptions: [],
+  })
+  @UseGuards(AuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @Patch('profileType')
+  async updateUserProfileType(
+    @AuthenticatedUser() user: UserEntity,
+    @Body() dto: UpdateUserProfileTypeRequest,
+  ): Promise<ResponsesDataDto<UserInfoResponse>> {
+    const result = await this.userService.updateUserProfileType(
+      user.id,
+      dto.profileType,
+    );
 
     return new ResponsesDataDto(result);
   }

--- a/src/module/user/user.service.ts
+++ b/src/module/user/user.service.ts
@@ -11,6 +11,7 @@ import { RedisTTL } from '../cache/enum/cache.enum';
 import { ItemService } from '../item/item.service';
 import { PuzzleService } from '../puzzle/puzzle.service';
 import { USER_PROFILE_DEFAULT_IMG } from 'src/constant/image';
+import { ProfileType } from '../repository/enum/user.enum';
 
 @Injectable()
 export class UserService {
@@ -63,7 +64,7 @@ export class UserService {
   async getUsers(): Promise<UserEntity[]> {
     const users = await this.userRepositoryService.getUsers();
 
-    return users; 
+    return users;
   }
 
   async updateUserImage(
@@ -84,12 +85,28 @@ export class UserService {
 
     const user = await this.userRepositoryService.getUserById(userId);
     if (user.image && user.image !== USER_PROFILE_DEFAULT_IMG) {
-      await this.cloudStorageService.deleteFile(`user/${user.image.split('/').pop()}`);
+      await this.cloudStorageService.deleteFile(
+        `user/${user.image.split('/').pop()}`,
+      );
     }
 
     await this.userRepositoryService.updateUser({
       id: userId,
       image: imageUrl,
+    });
+
+    const result = await this.userRepositoryService.getUserById(userId);
+
+    return UserInfoResponse.from(result);
+  }
+
+  async updateUserProfileType(
+    userId: number,
+    profileType: ProfileType,
+  ): Promise<UserInfoResponse> {
+    await this.userRepositoryService.updateUser({
+      id: userId,
+      profileType,
     });
 
     const result = await this.userRepositoryService.getUserById(userId);

--- a/src/types/error/application-exceptions/401-unautorized.ts
+++ b/src/types/error/application-exceptions/401-unautorized.ts
@@ -54,3 +54,10 @@ export class InvalidWalletAddress extends ApplicationException {
     super(ExceptionCode.InvalidAddress, 'Wallet Address Different');
   }
 }
+
+export class LoginRequired extends ApplicationException {
+  constructor(resource: string = '$resource') {
+    const message = `Access to ${resource} requires login`;
+    super(ExceptionCode.LoginRequired, message);
+  }
+}

--- a/src/types/error/application-exceptions/403-forbidden.ts
+++ b/src/types/error/application-exceptions/403-forbidden.ts
@@ -1,0 +1,11 @@
+import { ExceptionCode } from 'src/constant/exception';
+import { ApplicationException } from '../application-exceptions.base';
+
+export class ProfileAccessDenied extends ApplicationException {
+  constructor() {
+    super(
+      ExceptionCode.ProfileAccessDenied,
+      'Profile access permission is denied',
+    );
+  }
+}


### PR DESCRIPTION
### 프로필 공개여부 설정 - /v1/user/profileType

- UserEntity - profilfeType(enum) 추가

`public`: 비로그인, 로그인 유저 모두 열람 가능
`private`: 로그인 유저만 열람 가능 **(기본값)**
`none`: 아무도 접근 불가

### 다른 유저 프로필 API - /v1/user/:walletAddress
💡 유저의 유니크값인 `walletAddress` 로 조회 💡
   

예외처리
- private 프로필에 비로그인 유저 접근 > 401, code=LOGIN_REQUIRED
- none 프로필에 로그인/비로그인 유저 접근 > 403, code=PROFILE_ACCESS_DENIED