### PR TITLE
Feat: 시즌 히스토리(랭킹, 퍼즐)

### DIFF
--- a/src/module/main.module.ts
+++ b/src/module/main.module.ts
@@ -34,6 +34,7 @@ import { WebSocketModule } from 'src/module/websocket/websocket.module';
 import { WebSocketExceptionFilter } from 'src/filter/websocket-exception-filter';
 import { UserStoryModule } from './user-story/user-story.module';
 import { RankingsModule } from './rankings/rankings.module';
+import { SeasonHistoryModule } from './season-history/season-history.module';
 
 @Module({
   imports: [
@@ -79,6 +80,7 @@ import { RankingsModule } from './rankings/rankings.module';
     ItemModule,
     WebSocketModule,
     RankingsModule,
+    SeasonHistoryModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/src/module/puzzle/dto/puzzle.dto.ts
+++ b/src/module/puzzle/dto/puzzle.dto.ts
@@ -129,8 +129,8 @@ export class PuzzlePieceDto {
   minted: boolean;
 
   @ApiProperty({
-    description: '',
-    type: '잠금해제된 퍼즐조각의 경우 "발행된 NFT와 소유 유저 정보"\n\
+    description:
+      '잠금해제된 퍼즐조각의 경우 "발행된 NFT와 소유 유저 정보"\n\
     그 외: "잠금해제에 필요한 아이템 정보"',
     oneOf: [
       {

--- a/src/module/puzzle/puzzle.service.ts
+++ b/src/module/puzzle/puzzle.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 
-import { PuzzlePieceDto, PuzzleResponse } from './dto/puzzle.dto';
 import { PuzzleRepositoryService } from '../repository/service/puzzle.repository.service';
 import { NftRepositoryService } from './../repository/service/nft.repository.service';
 import { SeasonEntity } from '../repository/entity/season.entity';
@@ -12,6 +11,8 @@ import {
 import { PaginatedList } from 'src/dto/response.dto';
 import { ContractKey } from '../repository/enum/contract.enum';
 import { PuzzlePieceEntity } from '../repository/entity/puzzle-piece.entity';
+import { PuzzlePieceDto } from '../season-history/dto/season-history.dto';
+import { PuzzleResponse } from './dto/puzzle.dto';
 
 @Injectable()
 export class PuzzleService {
@@ -32,6 +33,10 @@ export class PuzzleService {
 
   async getAllSeasons(): Promise<SeasonEntity[]> {
     return this.puzzleRepositoryService.getAllSeasons();
+  }
+
+  async getSeasonIfPast(seasonId: number): Promise<SeasonEntity> {
+    return this.puzzleRepositoryService.getSeasonIfPast(seasonId);
   }
 
   async getSeasonById(id: number): Promise<SeasonEntity> {

--- a/src/module/rankings/rankings.module.ts
+++ b/src/module/rankings/rankings.module.ts
@@ -7,5 +7,6 @@ import { RankingsService } from './rankings.service';
   imports: [PuzzleModule],
   providers: [RankingsService],
   controllers: [RankingsController],
+  exports: [RankingsService],
 })
 export class RankingsModule {}

--- a/src/module/rankings/rankings.service.ts
+++ b/src/module/rankings/rankings.service.ts
@@ -1,6 +1,8 @@
 import { Inject } from '@nestjs/common';
+
 import { PuzzleService } from '../puzzle/puzzle.service';
 import { Rankings } from './dto/rankings.dto';
+import { SeasonEntity } from '../repository/entity/season.entity';
 
 export class RankingsService {
   constructor(
@@ -9,16 +11,26 @@ export class RankingsService {
 
   async getCurrentSeasonRankings(): Promise<Rankings[]> {
     const thisSeason = await this.puzzleService.getThisSeason();
-    console.log('thisSeason', thisSeason);
+
+    return this.getSeasonRankings(thisSeason);
+  }
+
+  async getSeasonRankingsById(seasonId: number): Promise<Rankings[]> {
+    const season = await this.puzzleService.getSeasonById(seasonId);
+
+    return this.getSeasonRankings(season);
+  }
+
+  private async getSeasonRankings(
+    season: Pick<SeasonEntity, 'id' | 'totalPieces'>,
+  ): Promise<Rankings[]> {
     const getNftHoldingsPercentage = (nftholdings: number) => {
-      return (nftholdings / thisSeason.totalPieces) * 100;
+      return (nftholdings / season.totalPieces) * 100;
     };
 
     const nftHolders = await this.puzzleService.getNftHoldersBySeasonId(
-      thisSeason.id,
+      season.id,
     );
-
-    console.log('nftHolders', nftHolders);
 
     // address, name 으로 groupBy 해서 퍼즐 NFT 개수 카운트
     // -> 내림차순으로 정렬(동일 개수일 경우 순위 동일)

--- a/src/module/repository/entity/season.entity.ts
+++ b/src/module/repository/entity/season.entity.ts
@@ -13,6 +13,10 @@ export class SeasonEntity extends BaseEntity {
   title: string;
 
   @ApiProperty()
+  @Column('varchar', { nullable: true })
+  thumbnailUrl: string | null;
+
+  @ApiProperty()
   @Column('int')
   totalPieces: number;
 }

--- a/src/module/season-history/dto/season-history.dto.ts
+++ b/src/module/season-history/dto/season-history.dto.ts
@@ -1,0 +1,101 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose, plainToInstance, Type } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+import { Minted } from 'src/module/puzzle/dto/puzzle.dto';
+import {
+  Point,
+  PuzzlePieceEntity,
+} from 'src/module/repository/entity/puzzle-piece.entity';
+
+export class SeasonHistoryBaseRequest {
+  @ApiProperty()
+  @IsNumber()
+  @Type(() => Number)
+  readonly seasonId: number;
+}
+
+export class SeasonHistoryResponse {
+  @ApiProperty()
+  @Expose()
+  readonly id: number;
+
+  @ApiProperty()
+  @Expose()
+  readonly title: number;
+
+  @ApiProperty()
+  @Expose()
+  readonly thumbnailUrl: string;
+
+  @ApiProperty()
+  @Expose()
+  readonly totalPieces: number;
+
+  @ApiProperty()
+  @Expose()
+  readonly mintedPieces: number;
+}
+
+export class PuzzlePieceDto {
+  @ApiProperty({ description: '구역 ID' })
+  @Expose()
+  zoneId: number;
+
+  @ApiProperty()
+  @Expose()
+  zoneNameKr: string;
+
+  @ApiProperty()
+  @Expose()
+  zoneNameUs: string;
+
+  @ApiProperty({ description: '퍼즐 조각 아이디' })
+  @Expose()
+  pieceId: number;
+
+  @ApiProperty({ type: Point, description: '퍼즐 조각 좌표 목록' })
+  @Expose()
+  coordinates: string;
+
+  @ApiProperty({ description: 'minted=이미 민트됨(잠금해제 완료)' })
+  @Expose()
+  minted: boolean;
+
+  @ApiProperty()
+  @Expose()
+  data: Minted | null;
+
+  static from(entity: PuzzlePieceEntity) {
+    const data = entity.minted ? Minted.from(entity) : null;
+
+    return plainToInstance(
+      this,
+      {
+        ...entity,
+        zoneId: entity.seasonZone.zoneId,
+        pieceId: entity.id,
+        zoneNameKr: entity.seasonZone.zone.nameKr,
+        zoneNameUs: entity.seasonZone.zone.nameUs,
+        data,
+      },
+      {
+        excludeExtraneousValues: true,
+      },
+    );
+  }
+}
+
+export class PuzzleHistoryResponse {
+  @ApiProperty({ description: '총 퍼즐 조각 수' })
+  @Expose()
+  readonly total: number;
+
+  @ApiProperty({ description: '민트된 퍼즐 조각 수' })
+  @Expose()
+  readonly minted: number;
+
+  @ApiProperty({ type: PuzzlePieceDto, isArray: true })
+  @Expose()
+  readonly pieces: PuzzlePieceDto[];
+}

--- a/src/module/season-history/season-history.controller.ts
+++ b/src/module/season-history/season-history.controller.ts
@@ -1,0 +1,82 @@
+import { Controller, Get, HttpStatus, Query } from '@nestjs/common';
+
+import {
+  PuzzleHistoryResponse,
+  SeasonHistoryBaseRequest,
+  SeasonHistoryResponse,
+} from './dto/season-history.dto';
+import { ApiDescription } from 'src/decorator/api-description.decorator';
+import { SeasonHistoryService } from './season-history.service';
+import { ResponsesListDto } from 'src/dto/responses-list.dto';
+import { Rankings } from '../rankings/dto/rankings.dto';
+import { ResponsesDataDto } from 'src/dto/responses-data.dto';
+import { ContentNotFoundError } from 'src/types/error/application-exceptions/404-not-found';
+
+@Controller('season-history')
+export class SeasonHistoryController {
+  constructor(private readonly seasonHistoryService: SeasonHistoryService) {}
+
+  @ApiDescription({
+    tags: ['Season History(비로그인 상태에서도 조회 가능 ★)'],
+    summary: '시즌 히스토리 목록',
+    description: '현재 시즌 제외, 비로그인 상태에서도 조회 가능 ★',
+    listResponse: {
+      schema: SeasonHistoryResponse,
+      status: HttpStatus.OK,
+    },
+  })
+  @Get()
+  async getSeasonHistoryList(): Promise<
+    ResponsesListDto<SeasonHistoryResponse>
+  > {
+    const lastSeasons = await this.seasonHistoryService.getSeasonHistory();
+
+    return new ResponsesListDto(lastSeasons);
+  }
+
+  @ApiDescription({
+    tags: ['Season History(비로그인 상태에서도 조회 가능 ★)'],
+    summary: '특정 시즌 랭킹 히스토리 조회',
+    description: '현재 시즌 ID 입력시 404 에러 발생',
+    listResponse: {
+      status: HttpStatus.OK,
+      schema: Rankings,
+    },
+    exceptions: [ContentNotFoundError],
+  })
+  @Get('rankings')
+  async getRankingsHistory(
+    @Query() query: SeasonHistoryBaseRequest,
+  ): Promise<ResponsesListDto<Rankings>> {
+    const rankings = await this.seasonHistoryService.getRankingsHistory(
+      query.seasonId,
+    );
+
+    return new ResponsesListDto(rankings);
+  }
+
+  @ApiDescription({
+    tags: ['Season History(비로그인 상태에서도 조회 가능 ★)'],
+    summary: '특정 시즌 퍼즐 히스토리 조회',
+    description:
+      '- 퍼즐 현황 데이터 API(/v1/puzzle/{seasonId} GET 와 거의 동일\n\n\
+    - mint 된 조각의 data 는 동일\n\n\
+    - minted = false 인 조각의 data 는 null\n\n\
+    현재 시즌 ID 입력시 404 에러 발생',
+    dataResponse: {
+      schema: PuzzleHistoryResponse,
+      status: HttpStatus.OK,
+    },
+    exceptions: [ContentNotFoundError],
+  })
+  @Get('puzzle')
+  async getPuzzleHistory(
+    @Query() query: SeasonHistoryBaseRequest,
+  ): Promise<ResponsesDataDto<PuzzleHistoryResponse>> {
+    const puzzleHistory = await this.seasonHistoryService.getPuzzleHistory(
+      query.seasonId,
+    );
+
+    return new ResponsesDataDto(puzzleHistory);
+  }
+}

--- a/src/module/season-history/season-history.module.ts
+++ b/src/module/season-history/season-history.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { SeasonHistoryController } from './season-history.controller';
+import { RepositoryModule } from '../repository/repository.module';
+import { SeasonHistoryService } from './season-history.service';
+import { RankingsModule } from '../rankings/rankings.module';
+
+@Module({
+  imports: [RepositoryModule, RankingsModule],
+  controllers: [SeasonHistoryController],
+  providers: [SeasonHistoryService],
+})
+export class SeasonHistoryModule {}

--- a/src/module/season-history/season-history.service.ts
+++ b/src/module/season-history/season-history.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+
+import {
+  PuzzleHistoryResponse,
+  PuzzlePieceDto,
+  SeasonHistoryResponse,
+} from './dto/season-history.dto';
+import { SeasonEntity } from '../repository/entity/season.entity';
+import { Rankings } from '../rankings/dto/rankings.dto';
+import { RankingsService } from './../rankings/rankings.service';
+import { PuzzleRepositoryService } from './../repository/service/puzzle.repository.service';
+
+@Injectable()
+export class SeasonHistoryService {
+  constructor(
+    private readonly puzzleRepositoryService: PuzzleRepositoryService,
+    private readonly rankingsService: RankingsService,
+  ) {}
+
+  async getSeasonHistory(): Promise<SeasonHistoryResponse[]> {
+    const seasons: SeasonEntity[] =
+      await this.puzzleRepositoryService.findLastSeasons();
+
+    const getSeasonHistory = async (season: SeasonEntity) => {
+      const mintedPieces =
+        await this.puzzleRepositoryService.getMintedPiecesBySeasonId(season.id);
+
+      return plainToInstance(
+        SeasonHistoryResponse,
+        {
+          ...season,
+          mintedPieces,
+        },
+        { excludeExtraneousValues: true },
+      );
+    };
+
+    return Promise.all(seasons.map((season) => getSeasonHistory(season)));
+  }
+
+  async getRankingsHistory(seasonId: number): Promise<Rankings[]> {
+    await this.puzzleRepositoryService.getSeasonIfPast(seasonId);
+
+    return this.rankingsService.getSeasonRankingsById(seasonId);
+  }
+
+  async getPuzzleHistory(seasonId: number): Promise<PuzzleHistoryResponse> {
+    await this.puzzleRepositoryService.getSeasonIfPast(seasonId);
+
+    // 시즌 히스토리에서는 민트된 조각의 정보만 가져옴
+    const _pieces =
+      await this.puzzleRepositoryService.getPuzzlePiecesBySeasonIdWithoutItems(
+        seasonId,
+      );
+    const minted = _pieces.filter((e) => e.minted).length;
+
+    const total = _pieces[0].seasonZone.season.totalPieces;
+    const result: PuzzleHistoryResponse = {
+      total,
+      minted,
+      pieces: _pieces.map((e) => PuzzlePieceDto.from(e)),
+    };
+
+    return result;
+  }
+}


### PR DESCRIPTION


전부 비로그인 유저 접근 가능! 

## 1) 시즌 히스토리 목록 
_/v1/season-history_ **GET**

- 현재 시즌 제외 과거 시즌만 리턴

## 2) 특정 시즌의 퍼즐 히스토리
_/v1/season-history/puzzle_ **GET**

현재는 시즌의` 퍼즐 이미지`가 프론트엔드 프로젝트 안에 포함되어 있는데
1. 각 시즌의 퍼즐 이미지를 s3 에 올리고 그 url 을 DB 에 저장하고, API 에서는 s3 URL을 리턴해서 좌표를 계산하는 방식으로 할지,
2. 기존대로 프론트엔드 코드에 포함할지는
다같이 얘기를 한 번 해봐야할것같아요!! 
(1 으로 하면 API 응답에 퍼즐 이미지 url 도 포함하는걸로 수정 필요)


## 2) 특정 시즌의 랭킹 히스토리
_/v1/season-history/ranking_ **GET**


## 참고

<img width="364" alt="image" src="https://github.com/user-attachments/assets/7e1af2e4-108d-4f9a-a204-21096737e2a6">
<img width="418" alt="image" src="https://github.com/user-attachments/assets/0e7af978-1176-40ab-beb1-4eaa8f2f55c2">
<img width="401" alt="image" src="https://github.com/user-attachments/assets/bf5bfe3a-259b-463f-9e24-bc338f6a5aac">

