### PR TITLE
Feat/profile api v2

### DIFF
--- a/src/module/puzzle/puzzle.service.ts
+++ b/src/module/puzzle/puzzle.service.ts
@@ -80,6 +80,7 @@ export class PuzzleService {
     while (hasMore) {
       const puzzles = (
         await this.puzzleRepositoryService.findPuzzlesByUserId(userId, {
+          page,
           count: 100,
         })
       ).list;

--- a/src/module/puzzle/puzzle.service.ts
+++ b/src/module/puzzle/puzzle.service.ts
@@ -4,14 +4,17 @@ import { PuzzleRepositoryService } from '../repository/service/puzzle.repository
 import { NftRepositoryService } from './../repository/service/nft.repository.service';
 import { SeasonEntity } from '../repository/entity/season.entity';
 import {
+  PuzzlePieces,
   UserPuzzleDetailResponse,
+  UserPuzzlePiecesResponse,
   UserPuzzleRequest,
   UserPuzzleResponse,
 } from './user.puzzle.dto';
 import { PaginatedList } from 'src/dto/response.dto';
 import { ContractKey } from '../repository/enum/contract.enum';
 import { PuzzlePieceEntity } from '../repository/entity/puzzle-piece.entity';
-import { PuzzlePieceDto, PuzzleResponse } from './dto/puzzle.dto';
+import { PuzzlePieceDto } from '../season-history/dto/season-history.dto';
+import { PuzzleResponse } from './dto/puzzle.dto';
 
 @Injectable()
 export class PuzzleService {
@@ -64,6 +67,48 @@ export class PuzzleService {
       await this.puzzleRepositoryService.getTotalPiecesByUser(userId);
 
     return totalPieces;
+  }
+
+  async getUserPiecesBySeason(
+    userId: number,
+  ): Promise<UserPuzzlePiecesResponse> {
+    let page = 0;
+    let hasMore = true;
+
+    const puzzleMap = new Map<number, PuzzlePieces>();
+
+    while (hasMore) {
+      const puzzles = (
+        await this.puzzleRepositoryService.findPuzzlesByUserId(userId, {
+          count: 100,
+        })
+      ).list;
+
+      if (puzzles.length > 0) {
+        puzzles.forEach((puzzle) => {
+          const key = puzzle.seasonZoneId;
+          if (puzzleMap.has(key)) {
+            puzzleMap.get(key)!.count++;
+          } else {
+            puzzleMap.set(key, {
+              season: puzzle.seasonZone.season.title,
+              zone: puzzle.seasonZone.zone.nameUs,
+              image: puzzle.metadata.metadata.image,
+              count: 1,
+            });
+          }
+        });
+        page++;
+      } else {
+        hasMore = false;
+      }
+    }
+
+    const result: UserPuzzlePiecesResponse = {
+      puzzles: Array.from(puzzleMap.values()),
+    };
+
+    return result;
   }
 
   async getPuzzlesByUserId(

--- a/src/module/puzzle/user.puzzle.dto.ts
+++ b/src/module/puzzle/user.puzzle.dto.ts
@@ -5,6 +5,25 @@ import { IsNumber, IsOptional } from 'class-validator';
 import { PuzzlePieceEntity } from '../repository/entity/puzzle-piece.entity';
 import { PaginationDto } from 'src/dto/request.dto';
 
+export class PuzzlePieces {
+  @ApiProperty()
+  @Expose()
+  season: string;
+
+  @ApiProperty()
+  @Expose()
+  zone: string;
+
+  @ApiProperty()
+  @Expose()
+  @Type(() => Number)
+  count: number;
+
+  @ApiProperty()
+  @Expose()
+  image: string;
+}
+
 export class UserPuzzleRequest extends PaginationDto {
   @ApiProperty({ required: false })
   @IsOptional()
@@ -57,6 +76,12 @@ export class UserPuzzleResponse {
       { excludeExtraneousValues: true },
     );
   }
+}
+
+export class UserPuzzlePiecesResponse {
+  @ApiProperty({ type: PuzzlePieces, isArray: true })
+  @Type(() => PuzzlePieces)
+  puzzles: PuzzlePieces[];
 }
 
 export class UserPuzzlePathParams {

--- a/src/module/quest/quest.service.ts
+++ b/src/module/quest/quest.service.ts
@@ -87,6 +87,10 @@ export class QuestService {
     return { isAlreadyOngoing: false };
   }
 
+  async findLogsByUser(userId: number): Promise<LogQuestEntity[]> {
+    return await this.questRepositoryService.findLogsByUser(userId);
+  }
+
   async findLogByIdAndUser(
     id: number,
     userId: number,

--- a/src/module/repository/service/quest.repository.service.ts
+++ b/src/module/repository/service/quest.repository.service.ts
@@ -91,6 +91,16 @@ export class QuestRepositoryService {
     await this.logRepository.update(log.id, log);
   }
 
+  async findLogsByUser(userId: number): Promise<LogQuestEntity[]> {
+    const log = await this.logRepository.find({
+      where: { userId },
+      relations: { quest: true, user: true },
+      order: { createdAt: 'DESC' },
+    });
+
+    return log;
+  }
+
   async findLogByIdAndUser(
     id: number,
     userId: number,

--- a/src/module/season-history/season-history.module.ts
+++ b/src/module/season-history/season-history.module.ts
@@ -9,5 +9,6 @@ import { RankingsModule } from '../rankings/rankings.module';
   imports: [RepositoryModule, RankingsModule],
   controllers: [SeasonHistoryController],
   providers: [SeasonHistoryService],
+  exports: [SeasonHistoryService],
 })
 export class SeasonHistoryModule {}

--- a/src/module/season-history/season-history.service.ts
+++ b/src/module/season-history/season-history.service.ts
@@ -45,6 +45,27 @@ export class SeasonHistoryService {
     return this.rankingsService.getSeasonRankingsById(seasonId);
   }
 
+  async getUserRankingHistory(walletAddress: string): Promise<Rankings[]> {
+    const seasons = await this.puzzleRepositoryService.getAllSeasons();
+
+    const rankings: Rankings[] = [];
+
+    for (const season of seasons) {
+      const rankingHistory = await this.rankingsService.getSeasonRankingsById(
+        season.id,
+      );
+      const userRanking = rankingHistory.find(
+        (ranking) => ranking.walletAddress === walletAddress,
+      );
+
+      if (userRanking) {
+        rankings.push(userRanking);
+      }
+    }
+
+    return rankings;
+  }
+
   async getPuzzleHistory(seasonId: number): Promise<PuzzleHistoryResponse> {
     await this.puzzleRepositoryService.getSeasonIfPast(seasonId);
 

--- a/src/module/user/dto/user.dto.ts
+++ b/src/module/user/dto/user.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty, IntersectionType } from '@nestjs/swagger';
-import { Expose, plainToInstance } from 'class-transformer';
+import { Expose, plainToInstance, Type } from 'class-transformer';
 import { IsEnum, IsNotEmpty, IsOptional } from 'class-validator';
+import { Item } from 'src/module/item/dto/item.dto';
+import { PuzzlePieces } from 'src/module/puzzle/user.puzzle.dto';
 import { UserEntity } from 'src/module/repository/entity/user.entity';
 import { ProfileType } from 'src/module/repository/enum/user.enum';
 
@@ -54,9 +56,39 @@ export class UserNftTotals {
   totalPieces: number;
 }
 
+export class UserNfts {
+  @ApiProperty()
+  @Expose()
+  items: Item[];
+
+  @ApiProperty()
+  @Expose()
+  puzzles: PuzzlePieces[];
+}
+
+export class UserHistory {
+  @ApiProperty({ description: '시즌 랭킹 1위' })
+  @Expose()
+  rankedFirst: number;
+
+  @ApiProperty({ description: '시즌 랭킹 3위' })
+  @Expose()
+  rankedThird: number;
+
+  @ApiProperty({ description: '퀘스트 연승' })
+  @Expose()
+  questStreak: number;
+}
+
 export class UserProfileResponse extends IntersectionType(
   UserInfoResponse,
   UserNftTotals,
+) {}
+
+export class OtherUserProfileResponse extends IntersectionType(
+  UserInfoResponse,
+  UserNfts,
+  UserHistory,
 ) {}
 
 export class UpdateUserNameRequest {

--- a/src/module/user/user.controller.ts
+++ b/src/module/user/user.controller.ts
@@ -20,6 +20,7 @@ import { AuthorizationToken } from 'src/constant/authorization-token';
 import { AuthGuard, PublicOrAuthGuard } from '../auth/auth.guard';
 import {
   ImageUploadDto,
+  OtherUserProfileResponse,
   UpdateUserNameRequest,
   UpdateUserProfileTypeRequest,
   UserInfoResponse,
@@ -91,7 +92,7 @@ export class UserController {
     },
     dataResponse: {
       status: HttpStatus.OK,
-      schema: UserProfileResponse,
+      schema: OtherUserProfileResponse,
     },
     exceptions: [ContentNotFoundError, ProfileAccessDenied, LoginRequired],
   })
@@ -101,7 +102,7 @@ export class UserController {
   async getOtherUserInfo(
     @Param('walletAddress') walletAddress: string,
     @AuthenticatedUser() user?: UserEntity,
-  ): Promise<ResponsesDataDto<UserProfileResponse>> {
+  ): Promise<ResponsesDataDto<OtherUserProfileResponse>> {
     const result = await this.userService.getOtherUserInfo(
       user?.id,
       walletAddress,

--- a/src/module/user/user.module.ts
+++ b/src/module/user/user.module.ts
@@ -5,9 +5,18 @@ import { UserController } from './user.controller';
 import { CloudStorageModule } from '../cloudStorage/cloudStorage.module';
 import { PuzzleModule } from '../puzzle/puzzle.module';
 import { ItemModule } from '../item/item.module';
+import { SeasonHistoryModule } from '../season-history/season-history.module';
+import { QuestModule } from '../quest/quest.module';
 
 @Module({
-  imports: [RepositoryModule, CloudStorageModule, PuzzleModule, ItemModule],
+  imports: [
+    RepositoryModule,
+    CloudStorageModule,
+    PuzzleModule,
+    ItemModule,
+    SeasonHistoryModule,
+    QuestModule,
+  ],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/src/module/user/user.service.ts
+++ b/src/module/user/user.service.ts
@@ -101,10 +101,11 @@ export class UserService {
     let rankedThird = 0;
 
     for (const ranking of rankings) {
-      if (ranking.rank === 1) {
-        rankedFirst++;
-      } else if (ranking.rank === 3) {
+      if (ranking.rank <= 3) {
         rankedThird++;
+        if (ranking.rank === 1) {
+          rankedFirst++;
+        }
       }
     }
 


### PR DESCRIPTION
### 수정사항
**/v1/user/{walletAddress}**
응답
```
    "id": 0,
    "email": "string",
    "name": "string",
    "image": "string",
    "profileType": "string",
    "level": 0,
    "walletAddress": "string",
    "createdAt": "2024-08-17T15:00:06.765Z",

    // 유저가 보유한 item nft 목록
    "items": [ 
        "count": 0, // 보유 개수
        "name": "string", // 이름
        "image": "string", // 섬넬 URL
    ],
    
    // 유저가 보유한 puzzle nft 목록 (시즌-존 별)
    "puzzles": [ 
        "season": "string", // season 영문 이름
        "zone": "string", // zone 영문 이름
        "image": "string", // 섬넬 URL
        "count": 0 // 보유 개수

    ],
    
    "rankedFirst": 0, // 상위 랭킹 1위 전적
    "rankedThird": 0, // 상위 랭킹 3위 이상 전적
    "questStreak": 0 // 퀘스트 연승 전적
```

### 추가사항

1. puzzle.service.ts
**getUserPiecesBySeason** : 시즌-존 별 퍼즐 조각 보유 개수 조회

2. quest.service.ts
**findLogsByUser** : 유저 퀘스트 로그 기록 조회

3. season-history.service.ts
**getUserRankingHistory** : 유저 랭킹 기록 조회

4. user.service.ts
**getTopRankCounts** : 랭킹 히스토리 통계 함수
**getQuestStreak** : 퀘스트 전적 통계 함수
_재사용 없이 다른 사용자 프로필 조회만을 위한 함수로 user.service.ts 내 작성하였음_
