### PR TITLE
덕새 점프 게이트웨이

### DIFF
--- a/src/module/cache/enum/cache.enum.ts
+++ b/src/module/cache/enum/cache.enum.ts
@@ -2,6 +2,7 @@ export enum RedisKey {
   EditUserName = 'edit_username',
   transactionCollectionInProgress = 'tx_collection_in_progress',
   AcidRainScore = 'quest:acidrain:score',
+  DuksaeJumpScore = 'quest:duksaejump:score',
 }
 
 export enum RedisTTL {

--- a/src/module/quest/quest.service.ts
+++ b/src/module/quest/quest.service.ts
@@ -12,6 +12,7 @@ import { LogQuestEntity } from '../repository/entity/log-quest.entity';
 import { LimitExceededError } from 'src/types/error/application-exceptions/409-conflict';
 import { NoOngoingQuestError } from 'src/types/error/application-exceptions/400-bad-request';
 import { GuestInfo } from './rest/types/guest';
+import { QuestType } from '../repository/enum/quest.enum';
 
 @Injectable()
 export class QuestService {
@@ -32,6 +33,18 @@ export class QuestService {
       quests = await this.questRepositoryService.findQuests(
         logs.map((e) => e.quest?.id),
       );
+
+      const duksaeJump = await this.questRepositoryService.findQuestByType(
+        QuestType.DuksaeJump,
+      );
+      const duksaeJumpLogs = logs.filter(
+        (log) => log.questId === duksaeJump.id,
+      );
+
+      // TODO: 임시 상수 10
+      if (duksaeJumpLogs.length < 10) {
+        quests.push(duksaeJump);
+      }
     } else {
       quests = await this.questRepositoryService.findQuests();
     }

--- a/src/module/quest/quest.service.ts
+++ b/src/module/quest/quest.service.ts
@@ -33,18 +33,6 @@ export class QuestService {
       quests = await this.questRepositoryService.findQuests(
         logs.map((e) => e.quest?.id),
       );
-
-      const duksaeJump = await this.questRepositoryService.findQuestByType(
-        QuestType.DuksaeJump,
-      );
-      const duksaeJumpLogs = logs.filter(
-        (log) => log.questId === duksaeJump.id,
-      );
-
-      // TODO: 임시 상수 10
-      if (duksaeJumpLogs.length < 10) {
-        quests.push(duksaeJump);
-      }
     } else {
       quests = await this.questRepositoryService.findQuests();
     }

--- a/src/module/quest/websocket/constants/quest-duksaejump.ts
+++ b/src/module/quest/websocket/constants/quest-duksaejump.ts
@@ -1,0 +1,23 @@
+const DuksaeJumpPrefix: string = 'quest:duksae-jump';
+
+export const CORRECT_JUMP_POINTS: number = 1;
+export const MISSING_JUMP_PENALTY: number = 1;
+
+export const DuksaeJumpMessagePattern = {
+  // 서버 수신 메시지
+  Inbound: {
+    Start: [DuksaeJumpPrefix, 'start'].join(':'),
+    Success: [DuksaeJumpPrefix, 'success'].join(':'),
+    Fail: [DuksaeJumpPrefix, 'fail'].join(':'),
+  },
+
+  // 서버 발신 메시지
+  Outbound: {
+    Object: 'object',
+    Speed: 'speed',
+    Health: 'Health',
+    Score: 'score',
+    GameOver: 'gameover',
+    Result: 'result',
+  },
+};

--- a/src/module/quest/websocket/constants/quest-duksaejump.ts
+++ b/src/module/quest/websocket/constants/quest-duksaejump.ts
@@ -15,7 +15,7 @@ export const DuksaeJumpMessagePattern = {
   Outbound: {
     Object: 'object',
     Speed: 'speed',
-    Health: 'Health',
+    Health: 'health',
     Score: 'score',
     GameOver: 'gameover',
     Result: 'result',

--- a/src/module/quest/websocket/dto/quest-duksaejump.dto.ts
+++ b/src/module/quest/websocket/dto/quest-duksaejump.dto.ts
@@ -1,0 +1,43 @@
+import { RedisKey } from 'src/module/cache/enum/cache.enum';
+
+export class StartDuksaeJumpMessageBody {
+  logId: number;
+  gamePanelOffsetWidth: number;
+}
+
+export type DuksaeJumpQuestData = {
+  objectSpeed: number;
+  objectMaxSpeed: number;
+  speedIncreaseRate: number;
+  speedIncreaseInterval: number;
+  gameoverLimit: number; // 부딪힌 장애물 최대 허용 개수
+  passingScore: number; // 성공 점수 (달성 시, 게임 종료)
+};
+
+export class DuksaeJump {
+  scoreKey: string;
+
+  constructor(logId: number, clientId: string, userId: number | null) {
+    this.scoreKey = [
+      RedisKey.DuksaeJumpScore,
+      'logId',
+      logId,
+      'clientId',
+      clientId,
+      'userId',
+      userId,
+    ].join(':');
+  }
+
+  static getObjectSpeedKey(clientId: string): string {
+    return [clientId, 'speed'].join(':');
+  }
+
+  static getHealthPointKey(clientId: string): string {
+    return [clientId, 'health'].join(':');
+  }
+
+  static getPassingScoreKey(clientId: string): string {
+    return [clientId, 'passing'].join(':');
+  }
+}

--- a/src/module/quest/websocket/quest-duksaejump.gateway.ts
+++ b/src/module/quest/websocket/quest-duksaejump.gateway.ts
@@ -129,6 +129,10 @@ export class QuestDuksaeJumpGateWay
 
     // 장애물의 속도 업데이트 (기존 장애물 포함)
     const updateObjectSpeeds = async () => {
+      await new Promise((resolve) =>
+        setTimeout(resolve, quest.speedIncreaseInterval),
+      );
+
       while (true) {
         const hp = parseFloat(
           await this.memory.find(DuksaeJump.getHealthPointKey(client.id)),
@@ -146,6 +150,8 @@ export class QuestDuksaeJumpGateWay
           DuksaeJump.getObjectSpeedKey(client.id),
           objectSpeed,
         );
+
+        client.emit(MessagePattern.Outbound.Speed, objectSpeed);
 
         // 장애물 속도 업데이트
         await new Promise((resolve) =>
@@ -168,7 +174,6 @@ export class QuestDuksaeJumpGateWay
           objects[Math.floor(Math.random() * objects.length)];
 
         client.emit(MessagePattern.Outbound.Object, randomObject);
-        client.emit(MessagePattern.Outbound.Speed, objectSpeed);
 
         // 새로운 장애물의 속도에 맞춘 ttl 설정
         const ttl = calTtl();

--- a/src/module/quest/websocket/quest-duksaejump.gateway.ts
+++ b/src/module/quest/websocket/quest-duksaejump.gateway.ts
@@ -1,0 +1,243 @@
+// TODO: 부딪힘 및 성공 여부 백엔드에서 처리
+
+import { Inject, Logger, UseFilters, UseGuards } from '@nestjs/common';
+import {
+  ConnectedSocket,
+  MessageBody,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  OnGatewayInit,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+  WsException,
+} from '@nestjs/websockets';
+import { WebSocketService } from 'src/module/websocket/websocket.service';
+import { QuestService } from '../quest.service';
+import { Server, Socket } from 'socket.io';
+import { WebSocketExceptionFilter } from 'src/filter/websocket-exception-filter';
+import { LogIdAccessTokenGuard } from './log-id-access-token.guard';
+import {
+  CORRECT_JUMP_POINTS,
+  DuksaeJumpMessagePattern as MessagePattern,
+  MISSING_JUMP_PENALTY,
+} from './constants/quest-duksaejump';
+import {
+  DuksaeJump,
+  DuksaeJumpQuestData,
+  StartDuksaeJumpMessageBody,
+} from './dto/quest-duksaejump.dto';
+import { CacheService } from 'src/module/cache/cache.service';
+
+@WebSocketGateway({
+  cors: { origin: '*' },
+})
+export class QuestDuksaeJumpGateWay
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
+  @WebSocketServer()
+  server: Server;
+
+  constructor(
+    private readonly webSocketService: WebSocketService,
+
+    @Inject(CacheService)
+    private readonly memory: CacheService,
+
+    @Inject(QuestService)
+    private readonly questService: QuestService,
+  ) {}
+
+  afterInit(server: any) {
+    Logger.log('init', QuestDuksaeJumpGateWay.name);
+  }
+
+  handleConnection(client: any, ...args: any[]) {
+    Logger.log(`Client connected: ${client.id}`);
+    this.webSocketService.addClient(client);
+  }
+
+  handleDisconnect(client: Socket) {
+    Logger.log(`Client disconnected: ${client.id}`);
+    this.webSocketService.removeClient(client);
+  }
+
+  @UseFilters(new WebSocketExceptionFilter())
+  @UseGuards(LogIdAccessTokenGuard)
+  @SubscribeMessage(MessagePattern.Inbound.Start)
+  async handleStart(
+    @ConnectedSocket()
+    client: Socket,
+    @MessageBody()
+    data: StartDuksaeJumpMessageBody,
+  ): Promise<void> {
+    const log = client.log;
+    const quest: DuksaeJumpQuestData = JSON.parse(log.quest.quest);
+    const questData = new DuksaeJump(data.logId, client.id, client.user?.id);
+    const scoreKey = questData.scoreKey;
+
+    const objects = ['tree', 'bird', 'rock']; // 장애물 종류
+    let objectSpeed = quest.objectSpeed; // 장애물 생성 주기 (밀리초)
+
+    // 동일한 logId 로 이미 퀘스트를 진행한 이력이 있는지 확인(중복 불가)
+    const isAlreadyStarted = (await this.memory.find(scoreKey)) !== null;
+    if (isAlreadyStarted) {
+      throw new WsException('Already Started');
+    }
+
+    // 점수, 목숨 세팅
+    await this.memory.set(scoreKey, 0);
+    await this.memory.set(
+      DuksaeJump.getHealthPointKey(client.id),
+      quest.gameoverLimit,
+    );
+
+    // 이후 점수 계산을 위해 client id 와 score key 매핑
+    await this.memory.set(client.id, scoreKey);
+
+    // 합격 점수 컷 저장
+    await this.memory.set(
+      DuksaeJump.getPassingScoreKey(client.id),
+      quest.passingScore,
+    );
+
+    // 덕새의 속도에 따라 장애물의 수명(ttl)을 동적으로 조정
+    const calTtl = () => {
+      return (data.gamePanelOffsetWidth / objectSpeed) * 1000;
+    };
+
+    // 최대 플레이 시간
+
+    // 1. 속도 증가에 걸리는 총 시간
+    let iterations = 0;
+    while (quest.objectSpeed > quest.objectMaxSpeed) {
+      quest.objectSpeed *= quest.speedIncreaseRate;
+      iterations++;
+    }
+    const totalIncreaseTime = iterations * quest.speedIncreaseInterval;
+
+    // 2. 평균 장애물 방출 시간
+    const averageTtl = (quest.objectSpeed + quest.objectMaxSpeed) / 2;
+    const averageEmit = (data.gamePanelOffsetWidth / averageTtl) * 1000;
+
+    // 3. 장애물 넘는 데 필요한 시간 (passingScore + gameoverLimit)
+    const totalObjects = quest.passingScore + quest.gameoverLimit;
+    const timeToPassObjects = averageEmit * totalObjects;
+
+    // 4. 총 플레이 시간 계산
+    const maxPlayTime = totalIncreaseTime + timeToPassObjects;
+
+    // 장애물의 속도 업데이트 (기존 장애물 포함)
+    const updateObjectSpeeds = async () => {
+      while (true) {
+        const hp = parseFloat(
+          await this.memory.find(DuksaeJump.getHealthPointKey(client.id)),
+        );
+        if (hp <= 0) {
+          return;
+        }
+
+        // 덕새 속도가 점점 빨라짐
+        objectSpeed = Math.max(
+          quest.objectMaxSpeed,
+          objectSpeed * quest.speedIncreaseRate,
+        );
+        await this.memory.set(
+          DuksaeJump.getObjectSpeedKey(client.id),
+          objectSpeed,
+        );
+
+        // 장애물 속도 업데이트
+        await new Promise((resolve) =>
+          setTimeout(resolve, quest.speedIncreaseInterval),
+        );
+      }
+    };
+
+    // 점점 빠르게 장애물 emit
+    const emitObject = async () => {
+      while (true) {
+        const hp = parseFloat(
+          await this.memory.find(DuksaeJump.getHealthPointKey(client.id)),
+        );
+        if (hp <= 0) {
+          return;
+        }
+
+        const randomObject =
+          objects[Math.floor(Math.random() * objects.length)];
+
+        client.emit(MessagePattern.Outbound.Object, randomObject);
+        client.emit(MessagePattern.Outbound.Speed, objectSpeed);
+
+        // 새로운 장애물의 속도에 맞춘 ttl 설정
+        const ttl = calTtl();
+
+        // 장애물 ttl 후 다음 장애물 등장
+        await new Promise((resolve) => setTimeout(resolve, ttl));
+      }
+    };
+
+    // maxPlayTime 후엔 게임 종료 후 승패 판단
+    setTimeout(async () => {
+      const hp = parseFloat(
+        await this.memory.find(DuksaeJump.getHealthPointKey(client.id)),
+      );
+      if (hp > 0) {
+        const data = JSON.parse(await this.memory.find(scoreKey));
+        const score = parseFloat(data.score);
+
+        const isSucceeded: boolean = score >= quest.passingScore;
+        client.emit(MessagePattern.Outbound.Result, {
+          result: isSucceeded,
+          score,
+        });
+        await this.questService.handleResult(isSucceeded, log);
+      }
+    }, maxPlayTime);
+
+    await Promise.all([updateObjectSpeeds(), emitObject()]);
+  }
+
+  @SubscribeMessage(MessagePattern.Inbound.Success)
+  async handleSuccess(
+    @ConnectedSocket()
+    client: Socket,
+  ): Promise<void> {
+    const scoreKey = await this.memory.find(client.id);
+
+    const score = await this.memory.incrbyfloat(scoreKey, CORRECT_JUMP_POINTS);
+    client.emit(MessagePattern.Outbound.Score, score);
+
+    const passingScore = parseFloat(
+      await this.memory.find(DuksaeJump.getPassingScoreKey(client.id)),
+    );
+    const isSucceeded: boolean = score >= passingScore;
+    if (isSucceeded) {
+      client.emit(MessagePattern.Outbound.Result, {
+        result: isSucceeded,
+        score,
+      });
+    }
+  }
+
+  @SubscribeMessage(MessagePattern.Inbound.Fail)
+  async handleFail(
+    @ConnectedSocket()
+    client: Socket,
+  ): Promise<void> {
+    const hp = await this.memory.incrbyfloat(
+      DuksaeJump.getHealthPointKey(client.id),
+      -MISSING_JUMP_PENALTY,
+    );
+
+    if (hp <= 0) {
+      const scoreKey = await this.memory.find(client.id);
+      const score = await this.memory.find(scoreKey);
+      client.emit(MessagePattern.Outbound.GameOver, score);
+      this.handleDisconnect(client);
+    } else {
+      client.emit(MessagePattern.Outbound.Health, hp);
+    }
+  }
+}

--- a/src/module/repository/entity/quest.entity.ts
+++ b/src/module/repository/entity/quest.entity.ts
@@ -13,7 +13,7 @@ export class QuestEntity extends BaseEntity {
   @Column('varchar')
   quest: string;
 
-  @Column('varchar')
+  @Column('varchar', { nullable: true })
   answer: string;
 
   @Column('int')

--- a/src/module/repository/enum/quest.enum.ts
+++ b/src/module/repository/enum/quest.enum.ts
@@ -1,4 +1,5 @@
 export enum QuestType {
   SpeedQuiz = 'SPEED_QUIZ',
   AcidRain = 'ACID_RAIN',
+  DuksaeJump = 'DUKSAE_JUMP',
 }

--- a/src/module/repository/service/quest.repository.service.ts
+++ b/src/module/repository/service/quest.repository.service.ts
@@ -22,12 +22,6 @@ export class QuestRepositoryService {
     return quest;
   }
 
-  async findQuestByType(type: QuestType): Promise<QuestEntity> {
-    const quest = await this.questRepository.findOneBy({ type });
-
-    return quest;
-  }
-
   async findQuests(excludes?: number[]): Promise<QuestEntity[]> {
     if (excludes?.every((e) => !!e)) {
       return this.questRepository.findBy({ id: Not(In(excludes)) });

--- a/src/module/repository/service/quest.repository.service.ts
+++ b/src/module/repository/service/quest.repository.service.ts
@@ -4,6 +4,7 @@ import { Repository, Not, In, IsNull } from 'typeorm';
 
 import { QuestEntity } from '../entity/quest.entity';
 import { LogQuestEntity } from '../entity/log-quest.entity';
+import { QuestType } from '../enum/quest.enum';
 
 @Injectable()
 export class QuestRepositoryService {
@@ -17,6 +18,12 @@ export class QuestRepositoryService {
 
   async findQuestById(id: number): Promise<QuestEntity> {
     const quest = await this.questRepository.findOneBy({ id });
+
+    return quest;
+  }
+
+  async findQuestByType(type: QuestType): Promise<QuestEntity> {
+    const quest = await this.questRepository.findOneBy({ type });
 
     return quest;
   }


### PR DESCRIPTION
### 게임 소개
플레이어는 덕새를 조종하여 목표 점수에 도달해야합니다. 점프를 하거나 하지않아서 장애물을 회피할 수 있습니다. 장애물은 세 가지 종류로 나무, 바위, 새가 있습니다. (임시) 플레이어가 장애물을 회피할 때마다 1점을 얻으며, 장애물을 회피하지 못하고 부딪힐 시, 목숨을 하나 잃습니다. 목숨을 모두 잃으면 게임 오버(종료)가 됩니다. 덕새는 일정 시간마다 속도가 빨라집니다. 점점 빠르게 다가오는 장애물을 넘어 목표 점수에 도달해보세요.
* * * 
### 서버 사이드 인바운드 메시지(클라이언트가 전송)
**1. 덕새 점프 퀘스트 시작**
- 이벤트 이름: `quest:duksae-jump:start`
- 요청 데이터:
```
{
        "logId": 3,
        "gamePanelOffsetWidth": 550  
}
```
`gamePanelOffsetWidth`: 장애물 수명 및 덕새 속도를 계산하기 위함

**2. 장애물 넘기 성공**
- 이벤트 이름: `quest:duksae-jump:success`

**3. 장애물 넘기 실패(부딪힘)**
- 이벤트 이름: `quest:duksae-jump:fail`

* * *
### 서버 사이드 아웃바운드 메세지(클라이언트가 수신)
**1. 새로운 장애물**
- 이벤트 이름: `object`
- 응답 데이터: `string` (장애물 종류)

**2. 덕새 초기 속도**
- 이벤트 이름: `speed'
- 응답 데이터: `number`
   : 일정시간마다 전송
- 덕새 속도가 변경되는 간격 = /v1/quest/start POST 응답의 quest.speedIncreaseInterval

**3. 남은 목숨 (남은 목숨 변동있을때마다)**
- 이벤트 이름: `health`
- 응답 데이터: `number`
- 목숨 개수 = /v1/quest/start POST 응답의 quest.gameoverLimit

**4. 점수 (남은 점수 변동 있을때마다)**
- 이벤트 이름: `score`
- 응답 데이터: `number`

**5. 게임 오버 (최종 실패)**
- 이벤트 이름: `gameover`
- 응답 데이터: `number` (점수)
   : 목숨이 0이 될 경우, 즉시 게임 실패 처리
   
**6. 게임 최종 결과 (목표 점수를 달성했을 때)**
- 이벤트 이름: `result`
- 응답 데이터:  
```
{
            "result": true,
            "score": 3
}
```
* * *
**/v1/quest/start POST** 응답의 quest 값
```
export type DuksaeJumpQuestData = {
  objectSpeed: number; // 덕새 초기 속도 (값이 작을 수록 빠름)
  objectMaxSpeed: number; // 덕새 최대 속도
  speedIncreaseRate: number; // 덕새 속도 증가율
  speedIncreaseInterval: number; // 덕새 속도 증가 간격
  gameoverLimit: number; // 부딪힌 장애물 최대 허용 개수
  passingScore: number; // 성공 점수 (달성 시, 게임 종료)
};
```