### PR TITLE
Feat: 덕새 점프 목표 변경. 회피 성공 횟수 -> 도달한 거리

### DIFF
--- a/src/module/quest/websocket/constants/quest-duksaejump.ts
+++ b/src/module/quest/websocket/constants/quest-duksaejump.ts
@@ -1,6 +1,5 @@
 const DuksaeJumpPrefix: string = 'quest:duksae-jump';
 
-export const CORRECT_JUMP_POINTS: number = 1;
 export const MISSING_JUMP_PENALTY: number = 1;
 
 export const DuksaeJumpMessagePattern = {

--- a/src/module/quest/websocket/constants/quest-duksaejump.ts
+++ b/src/module/quest/websocket/constants/quest-duksaejump.ts
@@ -15,7 +15,6 @@ export const DuksaeJumpMessagePattern = {
     Object: 'object',
     Speed: 'speed',
     Health: 'health',
-    Score: 'score',
     GameOver: 'gameover',
     Result: 'result',
   },

--- a/src/module/quest/websocket/dto/quest-duksaejump.dto.ts
+++ b/src/module/quest/websocket/dto/quest-duksaejump.dto.ts
@@ -5,6 +5,10 @@ export class StartDuksaeJumpMessageBody {
   gamePanelOffsetWidth: number;
 }
 
+export class ScoreMessageBody {
+  score: number;
+}
+
 export type DuksaeJumpQuestData = {
   objectSpeed: number;
   objectMaxSpeed: number;
@@ -27,10 +31,6 @@ export class DuksaeJump {
       'userId',
       userId,
     ].join(':');
-  }
-
-  static getObjectSpeedKey(clientId: string): string {
-    return [clientId, 'speed'].join(':');
   }
 
   static getHealthPointKey(clientId: string): string {


### PR DESCRIPTION
### 게임 소개
플레이어는 덕새를 조종하여 **목표 점수**에 도달해야합니다. 점프를 하거나 하지않아서 장애물을 회피할 수 있습니다. 장애물은 세 가지 종류로 나무, 바위, 새가 있습니다. ~~플레이어가 장애물을 회피할 때마다 1점을 얻으며,~~ 장애물을 회피하지 못하고 부딪힐 시, 목숨을 하나 잃습니다. 목숨을 모두 잃으면 게임 오버(종료)가 됩니다. 덕새는 일정 시간마다 속도가 빨라집니다. 점점 빠르게 다가오는 장애물을 넘어 목표 점수에 도달해보세요.
* * *
### 서버 사이드 인바운드 메시지(클라이언트가 전송)
**1. 덕새 점프 퀘스트 시작**
- 이벤트 이름: `quest:duksae-jump:start`
- 요청 데이터:
```
{
        "logId": 3,
        "gamePanelOffsetWidth": 550  
}
```
`gamePanelOffsetWidth`: 장애물 수명 및 덕새 속도를 계산하기 위함

**2. 목표 점수(거리) 도달**
- 이벤트 이름: `quest:duksae-jump:success`

**3. 장애물 넘기 실패(부딪힘)**
- 이벤트 이름: `quest:duksae-jump:fail`

* * *
* ### 서버 사이드 아웃바운드 메세지(클라이언트가 수신)
**1. 새로운 장애물**
- 이벤트 이름: `object`
- 응답 데이터: `string` (장애물 종류)

**2. 덕새 초기 속도**
- 이벤트 이름: `speed'
- 응답 데이터: `number`
   : 일정시간마다 전송
- 덕새 속도가 변경되는 간격 = /v1/quest/start POST 응답의 quest.speedIncreaseInterval

**3. 남은 목숨 (남은 목숨 변동있을때마다)**
- 이벤트 이름: `health`
- 응답 데이터: `number`
- 목숨 개수 = /v1/quest/start POST 응답의 quest.gameoverLimit

**4. 게임 오버 (최종 실패)**
- 이벤트 이름: `gameover`
- 응답 데이터: `number` (점수)
   : 목숨이 0이 될 경우, 즉시 게임 실패 처리
   
**5. 게임 최종 결과 (목표 점수를 달성했을 때)**
- 이벤트 이름: `result`
- 응답 데이터:  
```
{
            "result": true,
            "score": 3
}
```
* * *
**/v1/quest/start POST** 응답의 quest 값
```
export type DuksaeJumpQuestData = {
  objectSpeed: number; // 덕새 초기 속도 (값이 클수록 빠름)
  objectMaxSpeed: number; // 덕새 최대 속도
  speedIncreaseRate: number; // 덕새 속도 증가율
  speedIncreaseInterval: number; // 덕새 속도 증가 간격
  gameoverLimit: number; // 부딪힌 장애물 최대 허용 개수
  passingScore: number; // 성공 점수 (달성 시, 게임 종료)
};
```